### PR TITLE
Reorganize Hibernate Search management config for a Standalone mapper

### DIFF
--- a/extensions/hibernate-search-standalone-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/deployment/HibernateSearchStandaloneEnabled.java
+++ b/extensions/hibernate-search-standalone-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/deployment/HibernateSearchStandaloneEnabled.java
@@ -10,7 +10,7 @@ import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.HibernateSea
  */
 public class HibernateSearchStandaloneEnabled implements BooleanSupplier {
 
-    private final HibernateSearchStandaloneBuildTimeConfig config;
+    protected final HibernateSearchStandaloneBuildTimeConfig config;
 
     HibernateSearchStandaloneEnabled(HibernateSearchStandaloneBuildTimeConfig config) {
         this.config = config;

--- a/extensions/hibernate-search-standalone-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/deployment/HibernateSearchStandaloneManagementEnabled.java
+++ b/extensions/hibernate-search-standalone-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/deployment/HibernateSearchStandaloneManagementEnabled.java
@@ -1,7 +1,6 @@
 package io.quarkus.hibernate.search.standalone.elasticsearch.deployment;
 
 import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.HibernateSearchStandaloneBuildTimeConfig;
-import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.management.HibernateSearchStandaloneManagementConfig;
 
 /**
  * Supplier that can be used to only run build steps
@@ -9,17 +8,13 @@ import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.management.H
  */
 public class HibernateSearchStandaloneManagementEnabled extends HibernateSearchStandaloneEnabled {
 
-    private final HibernateSearchStandaloneManagementConfig config;
-
-    HibernateSearchStandaloneManagementEnabled(HibernateSearchStandaloneBuildTimeConfig config,
-            HibernateSearchStandaloneManagementConfig managementConfig) {
+    HibernateSearchStandaloneManagementEnabled(HibernateSearchStandaloneBuildTimeConfig config) {
         super(config);
-        this.config = managementConfig;
     }
 
     @Override
     public boolean getAsBoolean() {
-        return super.getAsBoolean() && config.enabled();
+        return super.getAsBoolean() && config.management().enabled();
     }
 
 }

--- a/extensions/hibernate-search-standalone-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/deployment/HibernateSearchStandaloneProcessor.java
+++ b/extensions/hibernate-search-standalone-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/deployment/HibernateSearchStandaloneProcessor.java
@@ -63,7 +63,6 @@ import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.HibernateSea
 import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.HibernateSearchStandaloneBuildTimeConfig.ElasticsearchIndexBuildTimeConfig;
 import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.HibernateSearchStandaloneRecorder;
 import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.HibernateSearchStandaloneRuntimeConfig;
-import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.management.HibernateSearchStandaloneManagementConfig;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.vertx.http.deployment.spi.RouteBuildItem;
@@ -370,10 +369,12 @@ class HibernateSearchStandaloneProcessor {
     @BuildStep(onlyIf = HibernateSearchStandaloneManagementEnabled.class)
     void createManagementRoutes(BuildProducer<RouteBuildItem> routes,
             HibernateSearchStandaloneRecorder recorder,
-            HibernateSearchStandaloneManagementConfig managementConfig) {
+            HibernateSearchStandaloneBuildTimeConfig hibernateSearchStandaloneBuildTimeConfig) {
+
+        String managementRootPath = hibernateSearchStandaloneBuildTimeConfig.management().rootPath();
 
         routes.produce(RouteBuildItem.newManagementRoute(
-                managementConfig.rootPath() + (managementConfig.rootPath().endsWith("/") ? "" : "/") + "reindex")
+                managementRootPath + (managementRootPath.endsWith("/") ? "" : "/") + "reindex")
                 .withRoutePathConfigKey("quarkus.hibernate-search-standalone.management.root-path")
                 .withRequestHandler(recorder.managementHandler())
                 .displayOnNotFoundPage()

--- a/extensions/hibernate-search-standalone-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/runtime/HibernateSearchStandaloneBuildTimeConfig.java
+++ b/extensions/hibernate-search-standalone-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/runtime/HibernateSearchStandaloneBuildTimeConfig.java
@@ -69,6 +69,12 @@ public interface HibernateSearchStandaloneBuildTimeConfig {
     Optional<String> backgroundFailureHandler();
 
     /**
+     * Management interface.
+     */
+    @ConfigDocSection
+    HibernateSearchStandaloneBuildTimeConfigManagement management();
+
+    /**
      * Configuration related to the mapping.
      */
     MappingConfig mapping();

--- a/extensions/hibernate-search-standalone-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/runtime/HibernateSearchStandaloneBuildTimeConfigManagement.java
+++ b/extensions/hibernate-search-standalone-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/runtime/HibernateSearchStandaloneBuildTimeConfigManagement.java
@@ -1,13 +1,10 @@
-package io.quarkus.hibernate.search.standalone.elasticsearch.runtime.management;
+package io.quarkus.hibernate.search.standalone.elasticsearch.runtime;
 
-import io.quarkus.runtime.annotations.ConfigPhase;
-import io.quarkus.runtime.annotations.ConfigRoot;
-import io.smallrye.config.ConfigMapping;
+import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
-@ConfigMapping(prefix = "quarkus.hibernate-search-standalone.management")
-@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
-public interface HibernateSearchStandaloneManagementConfig {
+@ConfigGroup
+public interface HibernateSearchStandaloneBuildTimeConfigManagement {
 
     /**
      * Root path for reindexing endpoints.


### PR DESCRIPTION
I figured ... you probably have enough to do already 😃 🙈 so here's a patch to your PR. There's also a management config in the standalone extension, so we probably want to make it look the same as the one for the ORM mapper, right?

Otherwise, your original changes look nice! 😃 🎉 
Feel free to squash this into your commit if you want to.