### PR TITLE
Infinispan integration tests need to spell out the need for an AP

### DIFF
--- a/integration-tests/infinispan-cache/pom.xml
+++ b/integration-tests/infinispan-cache/pom.xml
@@ -110,6 +110,17 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.infinispan.protostream</groupId>
+                            <artifactId>protostream-processor</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/integration-tests/infinispan-client/pom.xml
+++ b/integration-tests/infinispan-client/pom.xml
@@ -153,6 +153,17 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.infinispan.protostream</groupId>
+                            <artifactId>protostream-processor</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This fixes the problems with `integration-tests/infinispan-cache` and `integration-tests/infinispan-client`