### PR TITLE
Address guide category injection safety

### DIFF
--- a/docs/src/main/asciidoc/_examples/acme-serve-http-requests-tutorial.adoctxt
+++ b/docs/src/main/asciidoc/_examples/acme-serve-http-requests-tutorial.adoctxt
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Serve Http requests using the Acme extension
 include::_attributes.adoc[]
 :diataxis-type: tutorial
-:categories: web
 :extension-status: experimental
 
 Create an application that uses unique annotations from the experimental acme extension to define two endpoints:

--- a/docs/src/main/asciidoc/_templates/template-concept.adoc
+++ b/docs/src/main/asciidoc/_templates/template-concept.adoc
@@ -7,13 +7,12 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 TODO:
 - Title: https://quarkus.io/guides/doc-reference#titles-headings
 - Use the file name as the ID
-- Choose appropriate categories: https://quarkus.io/guides/doc-reference#categories
+- Add this file to the appropriate category in docs/src/main/resources/categories.yaml
 ////
 [id="..."]
 = Title using sentence capitalization
 include::_attributes.adoc[]
 :diataxis-type: concept
-:categories: ...
 ////
 :extension-status: preview
 TODO: uncomment the above for experimental or tech-preview content.

--- a/docs/src/main/asciidoc/_templates/template-howto.adoc
+++ b/docs/src/main/asciidoc/_templates/template-howto.adoc
@@ -7,13 +7,12 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 TODO:
 - Title: https://quarkus.io/guides/doc-reference#titles-headings
 - Use the file name as the ID
-- Choose appropriate categories: https://quarkus.io/guides/doc-reference#categories
+- Add this file to the appropriate category in docs/src/main/resources/categories.yaml
 ////
 [id="..."]
 = Title using sentence capitalization
 include::_attributes.adoc[]
 :diataxis-type: howto
-:categories: ...
 ////
 :extension-status: preview
 TODO: uncomment the above for experimental or tech-preview content.

--- a/docs/src/main/asciidoc/_templates/template-reference.adoc
+++ b/docs/src/main/asciidoc/_templates/template-reference.adoc
@@ -7,13 +7,12 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 TODO:
 - Title: https://quarkus.io/guides/doc-reference#titles-headings
 - Use the file name as the ID
-- Choose appropriate categories: https://quarkus.io/guides/doc-reference#categories
+- Add this file to the appropriate category in docs/src/main/resources/categories.yaml
 ////
 [id="..."]
 = Title using sentence capitalization
 include::_attributes.adoc[]
 :diataxis-type: reference
-:categories: ...
 ////
 :extension-status: preview
 TODO: uncomment the above for experimental or tech-preview content.

--- a/docs/src/main/asciidoc/_templates/template-tutorial.adoc
+++ b/docs/src/main/asciidoc/_templates/template-tutorial.adoc
@@ -7,13 +7,12 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 TODO:
 - Title: https://quarkus.io/guides/doc-reference#titles-headings
 - Use the file name as the ID
-- Choose appropriate categories: https://quarkus.io/guides/doc-reference#categories
+- Add this file to the appropriate category in docs/src/main/resources/categories.yaml
 ////
 [id="..."]
 = Title using sentence capitalization
 include::_attributes.adoc[]
 :diataxis-type: tutorial
-:categories: ...
 ////
 :extension-status: preview
 TODO: uncomment the above for experimental or tech-preview content.

--- a/docs/src/main/asciidoc/aesh.adoc
+++ b/docs/src/main/asciidoc/aesh.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Command Mode with Aesh
 include::_attributes.adoc[]
-:categories: command-line
 :summary: Develop command line applications with the Aesh extension.
 :topics: command-line,cli,aesh,ssh,websocket,terminal
 :extensions: io.quarkus:quarkus-aesh,io.quarkus:quarkus-aesh-websocket,io.quarkus:quarkus-aesh-ssh

--- a/docs/src/main/asciidoc/agent-mcp.adoc
+++ b/docs/src/main/asciidoc/agent-mcp.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Agent MCP
 include::_attributes.adoc[]
-:categories: tooling
 :summary: Learn more about the Quarkus Agent MCP server for AI coding agents
 :topics: agent-mcp,mcp,ai-agents
 

--- a/docs/src/main/asciidoc/all-builditems.adoc
+++ b/docs/src/main/asciidoc/all-builditems.adoc
@@ -8,7 +8,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Build Items
 include::_attributes.adoc[]
-:categories: writing-extensions
 :summary: Explore all the BuildItems you can consume/produce in your extensions.
 
 Here you can find a list of Build Items and the extension that provides them.

--- a/docs/src/main/asciidoc/all-config.adoc
+++ b/docs/src/main/asciidoc/all-config.adoc
@@ -8,7 +8,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = All configuration options
 include::_attributes.adoc[]
-:categories: core
 :summary: List all the configuration properties per extensions
 
 include::{generated-dir}/config/quarkus-all-config.adoc[opts=optional]

--- a/docs/src/main/asciidoc/amqp-dev-services.adoc
+++ b/docs/src/main/asciidoc/amqp-dev-services.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Dev Services for AMQP
 include::_attributes.adoc[]
-:categories: messaging
 :summary: Start AMQP automatically in dev and test modes.
 :extensions: io.quarkus:quarkus-messaging-amqp
 :topics: messaging,amqp,dev-services,testing,dev-mode

--- a/docs/src/main/asciidoc/amqp-reference.adoc
+++ b/docs/src/main/asciidoc/amqp-reference.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Reactive Messaging AMQP 1.0 Connector Reference Documentation
 include::_attributes.adoc[]
-:categories: messaging
 :extensions: io.quarkus:quarkus-messaging-amqp
 :topics: messaging,amqp
 

--- a/docs/src/main/asciidoc/amqp.adoc
+++ b/docs/src/main/asciidoc/amqp.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Getting Started to Quarkus Messaging with AMQP 1.0
 include::_attributes.adoc[]
-:categories: messaging
 :summary: This guide demonstrates how your Quarkus application can utilize Quarkus Messaging to interact with AMQP.
 :extensions: io.quarkus:quarkus-messaging-amqp
 :topics: messaging,amqp

--- a/docs/src/main/asciidoc/ansible.adoc
+++ b/docs/src/main/asciidoc/ansible.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Automate Quarkus deployment with Ansible
 include::_attributes.adoc[]
-:categories: command-line
 :summary: Build and deploy your Quarkus App using Ansible
 :topics: ansible,devops
 

--- a/docs/src/main/asciidoc/aot.adoc
+++ b/docs/src/main/asciidoc/aot.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Ahead-of-Time (AOT) Caching
 include::_attributes.adoc[]
-:categories: core, cloud
 :summary: This guide explains how to use Leyden AOT caching with Quarkus for dramatically faster startup times on JDK 24+.
 :topics: aot,leyden,startup,performance
 

--- a/docs/src/main/asciidoc/apicurio-registry-dev-services.adoc
+++ b/docs/src/main/asciidoc/apicurio-registry-dev-services.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Dev Services for Apicurio Registry
 include::_attributes.adoc[]
-:categories: messaging
 :summary: Start Apicurio Registry automatically in dev and test modes.
 :topics: messaging,kafka,apicurio,registry,dev-services,dev-mode,testing
 :extensions: io.quarkus:quarkus-apicurio-registry-avro,io.quarkus:quarkus-messaging-kafka

--- a/docs/src/main/asciidoc/assistant.adoc
+++ b/docs/src/main/asciidoc/assistant.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Dev Assistant
 include::_attributes.adoc[]
-:categories: writing-extensions
 :summary: Learn more about the Dev Assistant
 :topics: dev-ui, assistant, extension
 

--- a/docs/src/main/asciidoc/aws-lambda-http.adoc
+++ b/docs/src/main/asciidoc/aws-lambda-http.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = AWS Lambda with Quarkus REST, Undertow, or Reactive Routes
 :extension-status: preview
 include::_attributes.adoc[]
-:categories: cloud
 :summary: This guide explains how you can deploy Vert.x Web, Servlet, or RESTEasy microservices as an AWS Lambda.
 :devtools-no-gradle:
 :topics: aws,lambda,serverless,function,cloud

--- a/docs/src/main/asciidoc/aws-lambda-snapstart.adoc
+++ b/docs/src/main/asciidoc/aws-lambda-snapstart.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = AWS Lambda SnapStart Configuration
 include::_attributes.adoc[]
-:categories: cloud
 :summary: This document explains how to optimize your AWS Lambda application for SnapStart
 :topics: aws,lambda,serverless,function,snapstart,cloud
 

--- a/docs/src/main/asciidoc/aws-lambda.adoc
+++ b/docs/src/main/asciidoc/aws-lambda.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = AWS Lambda
 include::_attributes.adoc[]
-:categories: cloud
 :summary: This guide explains how you can deploy Quarkus-based AWS Lambdas.
 :topics: aws,lambda,serverless,function,cloud
 :extensions: io.quarkus:quarkus-amazon-lambda

--- a/docs/src/main/asciidoc/azure-functions-http.adoc
+++ b/docs/src/main/asciidoc/azure-functions-http.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Azure Functions with Quarkus REST, Undertow, or Reactive Routes
 :extension-status: preview
 include::_attributes.adoc[]
-:categories: cloud
 :summary: Deploy Vert.x Web, Servlet, or RESTEasy microservices as a Microsoft Azure Function.
 :topics: azure,serverless,function,cloud
 :extensions: io.quarkus:quarkus-azure-functions-http

--- a/docs/src/main/asciidoc/azure-functions.adoc
+++ b/docs/src/main/asciidoc/azure-functions.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Azure Functions
 :extension-status: preview
 include::_attributes.adoc[]
-:categories: cloud
 :summary: Integrate Quarkus with the Microsoft Azure functions that you have written.
 :topics: azure,serverless,function,cloud
 :extensions: io.quarkus:quarkus-azure-functions

--- a/docs/src/main/asciidoc/blaze-persistence.adoc
+++ b/docs/src/main/asciidoc/blaze-persistence.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Blaze-Persistence
 include::_attributes.adoc[]
-:categories: data
 :summary: This guide explains how to use Blaze-Persistence to simplify your data and DTO layers.
 :config-file: application.properties
 

--- a/docs/src/main/asciidoc/build-analytics.adoc
+++ b/docs/src/main/asciidoc/build-analytics.adoc
@@ -4,7 +4,6 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Build analytics
-:categories: analytics
 :summary: This guide presents what build analytics is and how to configure it.
 
 The Quarkus team has limited knowledge, from Maven download numbers, of the remarkable growth of Quarkus and the number of users reporting issues/concerns. Still, we need more insight into the platforms, operating system, Java combinations, and build tools our users employ.

--- a/docs/src/main/asciidoc/building-my-first-extension.adoc
+++ b/docs/src/main/asciidoc/building-my-first-extension.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Building my first extension
 include::_attributes.adoc[]
-:categories: writing-extensions
 :summary: Learn step by step how to build a simple extension.
 :topics: extensions
 

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Building a Native Executable
 include::_attributes.adoc[]
-:categories: getting-started, native
 :summary: Build native executables with GraalVM or Mandrel.
 :topics: native,graalvm,mandrel
 

--- a/docs/src/main/asciidoc/cache-infinispan-reference.adoc
+++ b/docs/src/main/asciidoc/cache-infinispan-reference.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Infinispan Cache
 :extension-status: preview
 include::_attributes.adoc[]
-:categories: data
 :summary: Use Infinispan as the Quarkus cache backend
 :topics: infinispan,cache,data
 :extensions: io.quarkus:quarkus-infinispan-cache,io.quarkus:quarkus-infinispan-client

--- a/docs/src/main/asciidoc/cache-redis-reference.adoc
+++ b/docs/src/main/asciidoc/cache-redis-reference.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Redis Cache
 :extension-status: preview
 include::_attributes.adoc[]
-:categories: data
 :summary: Use Redis as the Quarkus cache backend
 :topics: redis,cache,data
 :extensions: io.quarkus:quarkus-redis-cache,io.quarkus:quarkus-redis-client

--- a/docs/src/main/asciidoc/cache.adoc
+++ b/docs/src/main/asciidoc/cache.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Application Data Caching
 include::_attributes.adoc[]
-:categories: data
 :summary: This guide explains how to cache expensive method calls of your CDI beans using simple annotations.
 :topics: cache,data
 :extensions: io.quarkus:quarkus-cache

--- a/docs/src/main/asciidoc/camel.adoc
+++ b/docs/src/main/asciidoc/camel.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Apache Camel on Quarkus
 include::_attributes.adoc[]
-:categories: integration
 :summary: This guide covers the systems integration with Apache Camel
 :topics: camel,integration
 

--- a/docs/src/main/asciidoc/capabilities.adoc
+++ b/docs/src/main/asciidoc/capabilities.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Extension Capabilities
 include::_attributes.adoc[]
-:categories: writing-extensions
 :summary: How capabilities are implemented and used in Quarkus.
 :topics: extensions
 

--- a/docs/src/main/asciidoc/cassandra.adoc
+++ b/docs/src/main/asciidoc/cassandra.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using the Cassandra Client
 include::_attributes.adoc[]
-:categories: data
 :summary: This guide covers how to use the Apache Cassandra NoSQL database in Quarkus.
 :topics: data,cassandra
 

--- a/docs/src/main/asciidoc/cdi-integration.adoc
+++ b/docs/src/main/asciidoc/cdi-integration.adoc
@@ -4,7 +4,6 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = CDI Integration Guide
-:categories: writing-extensions
 :summary: Learn how to integrate your extension with Quarkus' CDI container.
 include::_attributes.adoc[]
 :numbered:

--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Contexts and Dependency Injection
 include::_attributes.adoc[]
-:categories: core
 :keywords: arc
 :summary: Go more in depth into the Quarkus implementation of CDI.
 :numbered:

--- a/docs/src/main/asciidoc/cdi.adoc
+++ b/docs/src/main/asciidoc/cdi.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Introduction to Contexts and Dependency Injection (CDI)
 include::_attributes.adoc[]
-:categories: core
 :keywords: qualifier event interceptor observer arc
 :summary: Quarkus DI solution is based on the [Jakarta Contexts and Dependency Injection 4.1](https://jakarta.ee/specifications/cdi/4.1/jakarta-cdi-spec-4.1.html) specification. This guide explains the basics of CDI.
 :numbered:

--- a/docs/src/main/asciidoc/centralized-log-management.adoc
+++ b/docs/src/main/asciidoc/centralized-log-management.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Centralized log management (Graylog, Logstash, Fluentd)
 include::_attributes.adoc[]
-:categories: observability
 :summary: This guide explains how to centralize your logs with Graylog, Logstash or Fluentd.
 :topics: observability,logging
 :extensions: io.quarkus:quarkus-logging-gelf,io.quarkus:quarkus-opentelemetry

--- a/docs/src/main/asciidoc/class-loading-reference.adoc
+++ b/docs/src/main/asciidoc/class-loading-reference.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Class Loading Reference
 include::_attributes.adoc[]
-:categories: architecture
 :summary: Learn more about Quarkus class loading infrastructure.
 :topics: internals,extensions
 

--- a/docs/src/main/asciidoc/cli-tooling.adoc
+++ b/docs/src/main/asciidoc/cli-tooling.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 [id="cli-tooling"]
 = Building Quarkus apps with Quarkus Command Line Interface (CLI)
 include::_attributes.adoc[]
-:categories: tooling
 :summary: Use the Quarkus CLI to create, build, run, and manage extensions for Quarkus projects.
 :topics: cli,tooling
 

--- a/docs/src/main/asciidoc/command-mode-reference.adoc
+++ b/docs/src/main/asciidoc/command-mode-reference.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Command Mode Applications
 include::_attributes.adoc[]
-:categories: core, command-line
 :summary: This reference guide explains how to develop command line applications with Quarkus.
 :topics: command-line,cli
 

--- a/docs/src/main/asciidoc/compose-dev-services.adoc
+++ b/docs/src/main/asciidoc/compose-dev-services.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Compose Dev Services
 include::_attributes.adoc[]
-:categories: core
 :summary: Configure custom Dev Services using Docker or Podman Compose.
 :topics: dev-services,dev-mode,testing,compose
 

--- a/docs/src/main/asciidoc/conditional-extension-dependencies.adoc
+++ b/docs/src/main/asciidoc/conditional-extension-dependencies.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Conditional Extension Dependencies
 include::_attributes.adoc[]
-:categories: writing-extensions
 :summary: Trigger the inclusion on additional extensions based on certain conditions.
 :topics: extensions
 

--- a/docs/src/main/asciidoc/config-extending-support.adoc
+++ b/docs/src/main/asciidoc/config-extending-support.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Extending Configuration Support
 include::_attributes.adoc[]
-:categories: core
 :summary: Extend and customize the Configuration.
 :numbered:
 :sectnums:

--- a/docs/src/main/asciidoc/config-mappings.adoc
+++ b/docs/src/main/asciidoc/config-mappings.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Mapping configuration to objects
 include::_attributes.adoc[]
-:categories: core
 :summary: Group multiple configuration properties into an object.
 :numbered:
 :sectnums:

--- a/docs/src/main/asciidoc/config-reference.adoc
+++ b/docs/src/main/asciidoc/config-reference.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Configuration Reference Guide
 include::_attributes.adoc[]
-:categories: core
 :summary: Learn more about how to configure your Quarkus applications.
 :numbered:
 :sectnums:

--- a/docs/src/main/asciidoc/config-secrets.adoc
+++ b/docs/src/main/asciidoc/config-secrets.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Secrets in Configuration
 include::_attributes.adoc[]
 :diataxis-type: core
-:categories: security
 
 Use encrypted configuration values to protect sensitive passwords, secrets, tokens and keys.
 

--- a/docs/src/main/asciidoc/config-yaml.adoc
+++ b/docs/src/main/asciidoc/config-yaml.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = YAML configuration
 include::_attributes.adoc[]
 :diataxis-type: howto
-:categories: core
 :summary: Optionally, use application.yaml instead of application.properties to configure your application.
 :topics: configuration
 :extensions: io.quarkus:quarkus-config-yaml

--- a/docs/src/main/asciidoc/config.adoc
+++ b/docs/src/main/asciidoc/config.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Configuring Your Application
 include::_attributes.adoc[]
-:categories: core
 :summary: Hardcoded values in your code is a no go (even if we all did it at some point ;-)). In this guide, we learn how to configure your application.
 :topics: configuration
 

--- a/docs/src/main/asciidoc/container-image.adoc
+++ b/docs/src/main/asciidoc/container-image.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Container Images
 include::_attributes.adoc[]
-:categories: cloud
 :summary: Learn how to build and push container images with Jib, OpenShift, Docker, or Podman as part of the Quarkus build.
 :topics: devops,cloud
 :extensions: io.quarkus:quarkus-container-image-openshift,io.quarkus:quarkus-container-image-jib,io.quarkus:quarkus-container-image-docker,io.quarkus:quarkus-container-image-podman,io.quarkus:quarkus-container-image-buildpack

--- a/docs/src/main/asciidoc/context-propagation.adoc
+++ b/docs/src/main/asciidoc/context-propagation.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Context Propagation in Quarkus
 include::_attributes.adoc[]
-:categories: core
 :summary: Learn more about how you can pass contextual information with SmallRye Context Propagation.
 :topics: context-propagation
 

--- a/docs/src/main/asciidoc/continuous-testing.adoc
+++ b/docs/src/main/asciidoc/continuous-testing.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Continuous Testing
 include::_attributes.adoc[]
-:categories: core
 :summary: Get early test feedback with Continuous Testing.
 :numbered:
 :sectnums:

--- a/docs/src/main/asciidoc/credentials-provider.adoc
+++ b/docs/src/main/asciidoc/credentials-provider.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using a Credentials Provider
 include::_attributes.adoc[]
-:categories: security
 :summary: This guides explains how to use the Vault credentials provider or implement your own custom one.
 :extension-status: preview
 :topics: security,credentials

--- a/docs/src/main/asciidoc/cyclonedx.adoc
+++ b/docs/src/main/asciidoc/cyclonedx.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 [id="cyclonedx"]
 = Generating and Using CycloneDX SBOMs
 include::_attributes.adoc[]
-:categories: tooling
 :summary: This guide explains how to generate and use SBOMs for Quarkus applications in the CycloneDX format.
 :topics: sbom
 :extensions: io.quarkus:quarkus-cyclonedx

--- a/docs/src/main/asciidoc/databases-dev-services.adoc
+++ b/docs/src/main/asciidoc/databases-dev-services.adoc
@@ -4,7 +4,6 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Dev Services for Databases
-:categories: data, tooling
 include::_attributes.adoc[]
 :topics: dev-services,data,database,datasource,dev-mode,testing
 :extensions: io.quarkus:quarkus-agroal,io.quarkus:quarkus-reactive-mysql-client,io.quarkus:quarkus-reactive-oracle-client,io.quarkus:quarkus-reactive-pg-client,io.quarkus:quarkus-jdbc-db2,io.quarkus:quarkus-jdbc-h2,io.quarkus:quarkus-jdbc-mariadb,io.quarkus:quarkus-jdbc-mssql,io.quarkus:quarkus-jdbc-mysql,io.quarkus:quarkus-jdbc-oracle,io.quarkus:quarkus-jdbc-postgresql

--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Configure data sources in {project-name}
 include::_attributes.adoc[]
 :diataxis-type: reference
-:categories: data,getting-started,reactive
 :topics: data,database,datasource,sql,jdbc,reactive
 :extensions: io.quarkus:quarkus-agroal,io.quarkus:quarkus-reactive-mysql-client,io.quarkus:quarkus-reactive-oracle-client,io.quarkus:quarkus-reactive-pg-client,io.quarkus:quarkus-reactive-db2-client,io.quarkus:quarkus-reactive-pg-client,io.quarkus:quarkus-reactive-mssql-client,io.quarkus:quarkus-jdbc-db2,io.quarkus:quarkus-jdbc-h2,io.quarkus:quarkus-jdbc-mariadb,io.quarkus:quarkus-jdbc-mssql,io.quarkus:quarkus-jdbc-mysql,io.quarkus:quarkus-jdbc-oracle,io.quarkus:quarkus-jdbc-postgresql
 

--- a/docs/src/main/asciidoc/deploying-to-azure-cloud.adoc
+++ b/docs/src/main/asciidoc/deploying-to-azure-cloud.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Deploying to Microsoft Azure Cloud
 include::_attributes.adoc[]
-:categories: cloud
 :summary: Deploy a Quarkus application to the Microsoft Azure cloud platform.
 :topics: devops,azure,cloud,deployment
 

--- a/docs/src/main/asciidoc/deploying-to-google-cloud.adoc
+++ b/docs/src/main/asciidoc/deploying-to-google-cloud.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Deploying to Google Cloud Platform (GCP)
 include::_attributes.adoc[]
-:categories: cloud
 :summary: This guide explains how to deploy a Quarkus application to Google Cloud.
 :topics: devops,google,gcp,cloud,deployment
 

--- a/docs/src/main/asciidoc/deploying-to-heroku.adoc
+++ b/docs/src/main/asciidoc/deploying-to-heroku.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Deploying to Heroku
 include::_attributes.adoc[]
-:categories: cloud
 :summary: Deploy your Quarkus applications on Heroku.
 :topics: devops,heroku,cloud,deployment,docker,podman
 

--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 [id="deploy-kubernetes"]
 = Kubernetes extension
 include::_attributes.adoc[]
-:categories: cloud, native
 :summary: This guide covers how to deploy a native application on Kubernetes.
 :topics: devops,kubernetes,cloud,deployment
 :extensions: io.quarkus:quarkus-kubernetes

--- a/docs/src/main/asciidoc/deploying-to-openshift-docker-howto.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift-docker-howto.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Deploying {project-name} Java applications to {openshift} by using a Docker build strategy
 include::_attributes.adoc[]
 :diataxis-type: howto
-:categories: cloud, native
 :summary: This guide describes how to build and deploy a {project-name} application on {openshift} by using the Docker build strategy.
 :topics: devops,kubernetes,openshift,cloud,deployment
 :extensions: io.quarkus:quarkus-openshift

--- a/docs/src/main/asciidoc/deploying-to-openshift-howto.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift-howto.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Deploying {project-name} applications to {openshift} in a single step
 include::_attributes.adoc[]
 :diataxis-type: howto
-:categories: cloud, native
 :summary: This guide describes how to build and deploy a Quarkus application to {openshift} in a single step.
 :topics: devops,kubernetes,openshift,cloud,deployment
 :extensions: io.quarkus:quarkus-openshift

--- a/docs/src/main/asciidoc/deploying-to-openshift-native-howto.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift-native-howto.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Deploying {project-name} applications compiled to native executables
 include::_attributes.adoc[]
 :diataxis-type: howto
-:categories: cloud, native
 :summary: This guide describes how to deploy a Quarkus application to {openshift} compiled to native executables.
 :topics: devops,kubernetes,openshift,cloud,deployment
 :extensions: io.quarkus:quarkus-openshift

--- a/docs/src/main/asciidoc/deploying-to-openshift-s2i-howto.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift-s2i-howto.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Using S2I to deploy {project-name} applications to {openshift}
 include::_attributes.adoc[]
 :diataxis-type: howto
-:categories: cloud, native
 :summary: This guide describes how to build and deploy a Quarkus application on {openshift} by using Source-to-Image (S2I).
 :topics: devops,kubernetes,openshift,cloud,deployment
 :extensions: io.quarkus:quarkus-openshift

--- a/docs/src/main/asciidoc/deploying-to-openshift.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 [id="deploying-to-openshift"]
 = Deploying {project-name} applications to {openshift}
 include::_attributes.adoc[]
-:categories: cloud, native
 :summary: This guide describes the deployment of {project-name} applications to {openshift}.
 :numbered:
 :sectnums:

--- a/docs/src/main/asciidoc/dev-mcp.adoc
+++ b/docs/src/main/asciidoc/dev-mcp.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Dev MCP
 include::_attributes.adoc[]
-:categories: writing-extensions
 :summary: Learn more about Dev MCP
 :topics: dev-mcp,dev-ui
 

--- a/docs/src/main/asciidoc/dev-mode-differences.adoc
+++ b/docs/src/main/asciidoc/dev-mode-differences.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = How dev mode differs from a production application
 include::_attributes.adoc[]
-:categories: architecture
 :summary: How dev mode differs from a production application
 :topics: internals,dev-mode
 

--- a/docs/src/main/asciidoc/dev-services.adoc
+++ b/docs/src/main/asciidoc/dev-services.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Dev Services Overview
 include::_attributes.adoc[]
-:categories: core
 :summary: An introduction to Dev Services and a list of all extensions that support Dev Services and their configuration options.
 :topics: dev-services,dev-mode,testing
 

--- a/docs/src/main/asciidoc/dev-ui.adoc
+++ b/docs/src/main/asciidoc/dev-ui.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Dev UI
 include::_attributes.adoc[]
-:categories: writing-extensions
 :summary: Learn more about Dev UI
 :topics: dev-ui,testing
 

--- a/docs/src/main/asciidoc/doc-concept.adoc
+++ b/docs/src/main/asciidoc/doc-concept.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Quarkus documentation content types
 include::_attributes.adoc[]
 :diataxis-type: concept
-:categories: contributing
 :fn-diataxis: footnote:diataxis[Procida, D. Diátaxis documentation framework. https://diataxis.fr/]
 :topics: internals,documentation
 

--- a/docs/src/main/asciidoc/doc-contribute-docs-howto.adoc
+++ b/docs/src/main/asciidoc/doc-contribute-docs-howto.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Contribute to Quarkus documentation
 include::_attributes.adoc[]
 :diataxis-type: howto
-:categories: contributing
 :fn-diataxis: footnote:diataxis[Procida, D. Diátaxis documentation framework. https://diataxis.fr/]
 :topics: internals,documentation
 
@@ -54,20 +53,22 @@ For example, `telemetry-micrometer.adoc` is a reference, and `telemetry-micromet
 = Secure a Quarkus application with basic authentication <2>
 include::_attributes.adoc[] <3>
 :diataxis-type: howto <4>
-:categories: security,web <5>
-<6>
+<5>
 ----
 <1> Set the `id` value to be the same as the file name but without the extension.
 <2> For information about how to create a good title for each content type, see xref:doc-reference.adoc#titles-and-headings[Titles and headings] on the "Quarkus style and content guidelines" page.
 <3> The `_attributes.adoc` include is required to ensure that attributes get resolved and the table of contents is generated.
 <4> Specify the diataxis type: `concept`, `howto`, `reference`, or `tutorial`.
-<5> Set at least one category to ensure that the content is findable on the link:https://quarkus.io/guides/[Quarkus documentation home page]. For a list of Quarkus categories, see xref:doc-reference.adoc#document-attributes-and-variables[Document attributes and variables] on the "Quarkus style and content guidelines" page.
-<6> Insert a blank line after all document attributes and before the abstract.
+<5> Insert a blank line after all document attributes and before the abstract.
 +
 [IMPORTANT]
 ====
 Ensure there are no blank lines between the document id and title, the attribute include (`include::_attributes.adoc[]`) and the declaration of other document attributes(`:attribute:`).
 ====
+
+. Add the guide file to the appropriate category or subcategory in `docs/src/main/resources/categories.yaml`.
++
+For more information, see xref:doc-reference.adoc#categories[Categories] on the "Quarkus style and content guidelines" page.
 
 . Add an abstract that describes the purpose of the guide.
 +

--- a/docs/src/main/asciidoc/doc-create-tutorial.adoc
+++ b/docs/src/main/asciidoc/doc-create-tutorial.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Creating a tutorial
 include::_attributes.adoc[]
 :diataxis-type: tutorial
-:categories: contributing
 :topics: internals,documentation
 
 Create a new tutorial that guides users through creating, running, and testing a Quarkus application that uses annotations from an imaginary extension.
@@ -45,20 +44,20 @@ Copy `docs/src/main/diataxis/_templates/template-tutorial.adoc` from the Quarkus
 [id="acme-serve-http-requests-tutorial"] // <1>
 = Serve Http requests using the Acme extension // <2>
 include::_attributes.adoc[] // <3>
-:categories: web // <4>
-:extension-status: experimental // <5>
+:extension-status: experimental // <4>
 ----
 
 <1> Use the file name as a unique id for the section.
 <2> Add the title as a top-level heading.
 <3> Include additional attributes that help define consistent formatting and provide source portability.
-<4> Specify the `web` category, as our imaginary extension works with Http requests.
-<5> Our imaginary `acme` extension is experimental, so we include the extension status declaration in the header.
+<4> Our imaginary `acme` extension is experimental, so we include the extension status declaration in the header.
 
 .Document Preview
 --
 The preview of your document should contain the chosen title as a styled header at the top of the page.
 --
+
+Add `acme-serve-http-requests-tutorial.adoc` to the appropriate category or subcategory in `docs/src/main/resources/categories.yaml`.
 
 == Add an abstract
 

--- a/docs/src/main/asciidoc/doc-reference.adoc
+++ b/docs/src/main/asciidoc/doc-reference.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Quarkus style and content guidelines
 include::_attributes.adoc[]
 :diataxis-type: reference
-:categories: contributing
 :topics: internals,documentation
 
 Guidelines are provided to help you to contribute clear and consistent content that is also sourced in the required diataxis structure and composition of Quarkus documentation.
@@ -150,7 +149,7 @@ Use the Quarkus templates to ensure that your content is consistent with the pre
 === Document header
 
 Each document should define a header for document-scoped attributes.
-Minimally, each document should define and id and a title, and include common attributes (`_attributes.adoc`).
+Minimally, each document should define an id and a title, include common attributes (`_attributes.adoc`), and set the diataxis type.
 
 [source,asciidoc]
 ----
@@ -158,14 +157,12 @@ Minimally, each document should define and id and a title, and include common at
 = Quarkus style and content guidelines // <2>
 \include::_attributes.adoc[] // <3>
 :diataxis-type: {type} // <4>
-:categories: contributing // <5>
 ----
 
 <1> Use the filename as the ID for the document.
 <2> Define the document title following guidance in <<titles-headings>>.
 <3> Include common document attributes.
 <4> Specify the diataxis type: `concept`, `howto`, `reference`, or `tutorial`.
-<5> Specify the relevant <<categories>> (comma separated).
 
 [[doc-header-optional]]
 ==== Other common document header attributes
@@ -413,40 +410,12 @@ examples:
 [[categories]]
 === Categories
 
-Quarkus documentation is grouped into the following categories.
+Quarkus documentation categories are maintained in `docs/src/main/resources/categories.yaml`.
+When you add, rename, or remove a guide, update that file so the guide appears in the appropriate category or subcategory on the documentation website.
 
-.Categories
-[cols="<m,<2",options="header"]
-|===
-|Category | Description
-| alt-languages | Support for other languages, namely Kotlin and Scala
-| architecture | Quarkus runtime and ecosystem architecture
-| business-automation | Business automation integrations
-| cloud | Integrations and support for cloud services
-| command-line | Command Line Applications
-| compatibility | Compatibility with other languages and frameworks
-| contributing | Guidance and references to help you contribute to Quarkus.
-| core | Information about how the Quarkus works
-| data | Topics related to using data sources with Quarkus
-| getting-started | Getting started materials
-| integration | Support for integration extensions (Camel)
-| messaging | Integrations with messaging systems like Kafka, AMQP, or RabbitMQ.
-| miscellaneous | Miscellaneous
-| native | Everything related to native executables
-| observability | Extensions and integrations for runtime and application observability
-| security | Security
-| serialization | Serialization
-| tooling | Tooling
-| web | Web
-| writing-extensions | Writing Extensions
-|===
-
-Tag your content to improve findability by adding at least one category to the categories attribute line in the <<document-header,document header>>. To add multiple categories, use comma-separated values. For example:
-
-[source,asciidoc]
-----
-:categories: contributing, data
-----
+Do not add or keep `:categories:` attributes in guide headers.
+The docs build injects generated category metadata into copied target sources from `categories.yaml`.
+The build also checks that every guide is listed in `categories.yaml` and that every listed guide exists.
 
 [[document-variables]]
 === Quarkus documentation variables

--- a/docs/src/main/asciidoc/drools.adoc
+++ b/docs/src/main/asciidoc/drools.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Defining and executing business rules with Drools
 include::_attributes.adoc[]
-:categories: rule engine
 :summary: Drools is the most used rule engine implementation in the Java ecosystem. The purpose of this guide is to show how to use to define and execute business rules in Quarkus using Drools.
 :topics: drools,rules,rule engine
 :extensions: org.drools:drools-quarkus

--- a/docs/src/main/asciidoc/duplicated-context.adoc
+++ b/docs/src/main/asciidoc/duplicated-context.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Duplicated context, context locals, asynchronous processing and propagation
 include::_attributes.adoc[]
 :diataxis-type: concept
-:categories: core, architecture
 :topics: internals,extensions
 
 When using a traditional, blocking, and synchronous framework, processing of each request is performed in a dedicated thread.

--- a/docs/src/main/asciidoc/elasticsearch-dev-services.adoc
+++ b/docs/src/main/asciidoc/elasticsearch-dev-services.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Dev Services for Elasticsearch
 include::_attributes.adoc[]
-:categories: data
 :summary: Start Elasticsearch automatically in dev and test modes
 :topics: data,search,elasticsearch,nosql,dev-services,testing,dev-mode
 :extensions: io.quarkus:quarkus-elasticsearch-java-client,io.quarkus:quarkus-elasticsearch-rest-client,io.quarkus:quarkus-hibernate-search-orm-elasticsearch

--- a/docs/src/main/asciidoc/elasticsearch.adoc
+++ b/docs/src/main/asciidoc/elasticsearch.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Connecting to an Elasticsearch cluster
 include::_attributes.adoc[]
-:categories: data
 :summary: This guide covers how to interact with an Elasticsearch cluster using the low level REST client or the Elasticsearch Java client.
 :topics: data,search,elasticsearch,nosql
 :extensions: io.quarkus:quarkus-elasticsearch-java-client,io.quarkus:quarkus-elasticsearch-rest-client

--- a/docs/src/main/asciidoc/extension-codestart.adoc
+++ b/docs/src/main/asciidoc/extension-codestart.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Extension codestart
 include::_attributes.adoc[]
-:categories: writing-extensions
 :summary: Provide users with initial code for extensions when generating Quarkus applications on code.quarkus.io and all the Quarkus tooling. This guide explains how to create and configure a Codestart for an extension.
 :topics: extensions,codestarts
 

--- a/docs/src/main/asciidoc/extension-faq.adoc
+++ b/docs/src/main/asciidoc/extension-faq.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Frequently asked questions about writing extensions
 include::_attributes.adoc[]
 :diataxis-type: howto
-:categories: extensions
 ////
 :extension-status: preview
 TODO: uncomment the above for experimental or tech-preview content.

--- a/docs/src/main/asciidoc/extension-maturity-matrix.adoc
+++ b/docs/src/main/asciidoc/extension-maturity-matrix.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = A maturity matrix for Quarkus extensions
 include::_attributes.adoc[]
 :diataxis-type: concept
-:categories: writing-extensions
 :topics: extensions
 :summary: Quarkus extensions can do a lot, or a little. This guide explains some of the capabilities extension authors might want to include.
 ////

--- a/docs/src/main/asciidoc/extension-metadata.adoc
+++ b/docs/src/main/asciidoc/extension-metadata.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus Extension Metadata
 include::_attributes.adoc[]
-:categories: writing-extensions
 :topics: extensions,codestarts
 
 Quarkus extensions are distributed as Maven JAR artifacts that application and other libraries may depend on. When a Quarkus application project is built, tested or edited using the Quarkus dev tools, Quarkus extension JAR artifacts will be identified on the application classpath by the presence of the Quarkus extension metadata files in them.

--- a/docs/src/main/asciidoc/extension-registry-user.adoc
+++ b/docs/src/main/asciidoc/extension-registry-user.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus Extension Registry
 include::_attributes.adoc[]
-:categories: architecture
 :summary: Learn more about the notion of extension registry and how you can use your own.
 :topics: internals,extensions
 

--- a/docs/src/main/asciidoc/extension-writing-dev-service.adoc
+++ b/docs/src/main/asciidoc/extension-writing-dev-service.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 [id="extension-writing-dev-service"]
 = Writing a Dev Service
 include::_attributes.adoc[]
-:categories: writing-extensions
 :diataxis-type: howto
 :topics: extensions
 

--- a/docs/src/main/asciidoc/flyway.adoc
+++ b/docs/src/main/asciidoc/flyway.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Flyway
 include::_attributes.adoc[]
-:categories: data
 :summary: This guide covers how to use the Flyway extension to manage your schema migrations.
 :migrations-path: src/main/resources/db/migration
 :config-file: application.properties

--- a/docs/src/main/asciidoc/funqy-aws-lambda-http.adoc
+++ b/docs/src/main/asciidoc/funqy-aws-lambda-http.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Funqy HTTP Binding with AWS Lambda 
 :extension-status: preview
 include::_attributes.adoc[]
-:categories: cloud
 :summary: This guide explains Funqy's AWS Lambda HTTP binding.
 :topics: aws,lambda,serverless,function,cloud,funqy
 :extensions: io.quarkus:quarkus-funqy-http,io.quarkus:quarkus-amazon-lambda-http

--- a/docs/src/main/asciidoc/funqy-aws-lambda.adoc
+++ b/docs/src/main/asciidoc/funqy-aws-lambda.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 :extension-status: preview
 :devtools-no-gradle:
 include::_attributes.adoc[]
-:categories: cloud
 :summary: This guide explains Funqy's AWS Lambda binding.
 :topics: aws,lambda,serverless,function,cloud,funqy
 :extensions: io.quarkus:quarkus-funqy-amazon-lambda

--- a/docs/src/main/asciidoc/funqy-azure-functions-http.adoc
+++ b/docs/src/main/asciidoc/funqy-azure-functions-http.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Funqy HTTP Binding with Azure Functions
 :extension-status: preview
 include::_attributes.adoc[]
-:categories: cloud
 :summary: Use Funqy HTTP binding with Microsoft Azure Functions to deploy your serverless Quarkus applications.
 :topics: azure,serverless,function,cloud,funqy
 :extensions: io.quarkus:quarkus-azure-functions-http

--- a/docs/src/main/asciidoc/funqy-gcp-functions-http.adoc
+++ b/docs/src/main/asciidoc/funqy-gcp-functions-http.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Funqy HTTP Binding with Google Cloud Functions
 :extension-status: preview
 include::_attributes.adoc[]
-:categories: cloud
 :summary: This guide explains Funqy's Google Cloud Platform Functions HTTP binding.
 :topics: google,gcp,serverless,function,cloud,funqy
 :extensions: io.quarkus:quarkus-funqy-http,io.quarkus:quarkus-google-cloud-functions-http

--- a/docs/src/main/asciidoc/funqy-gcp-functions.adoc
+++ b/docs/src/main/asciidoc/funqy-gcp-functions.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Funqy Google Cloud Functions
 :extension-status: preview
 include::_attributes.adoc[]
-:categories: cloud
 :summary: This guide explains Funqy's Google Cloud Platform Functions binding.
 :topics: google,gcp,serverless,function,cloud,funqy
 :extensions: io.quarkus:quarkus-funqy-http,io.quarkus:quarkus-funqy-google-cloud-functions

--- a/docs/src/main/asciidoc/funqy-http.adoc
+++ b/docs/src/main/asciidoc/funqy-http.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Funqy HTTP Binding (Standalone)
 include::_attributes.adoc[]
-:categories: cloud
 :summary: This guide explains Funqy's HTTP binding.
 :extension-status: preview
 :topics: serverless,function,cloud,funqy

--- a/docs/src/main/asciidoc/funqy-knative-events.adoc
+++ b/docs/src/main/asciidoc/funqy-knative-events.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Funqy Knative Events Binding
 include::_attributes.adoc[]
-:categories: cloud
 :summary: This guide explains Funqy's Knative Events binding.
 :devtools-no-gradle:
 :topics: serverless,function,cloud,funqy

--- a/docs/src/main/asciidoc/funqy.adoc
+++ b/docs/src/main/asciidoc/funqy.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Funqy
 include::_attributes.adoc[]
-:categories: cloud
 :summary: This guide explains basics of the Funqy framework, a simple portable cross-provider cloud function API.
 :extension-status: preview
 :topics: serverless,function,cloud,funqy

--- a/docs/src/main/asciidoc/gcp-functions-http.adoc
+++ b/docs/src/main/asciidoc/gcp-functions-http.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Google Cloud Functions (Serverless) with Quarkus REST, Undertow, or Reactive Routes
 :extension-status: preview
 include::_attributes.adoc[]
-:categories: cloud
 :summary: This guide explains how you can deploy Vert.x Web, Servlet, or RESTEasy microservices as a Google Cloud Function.
 :topics: google,gcp,serverless,function,cloud
 :extensions: io.quarkus:quarkus-google-cloud-functions-http

--- a/docs/src/main/asciidoc/gcp-functions.adoc
+++ b/docs/src/main/asciidoc/gcp-functions.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Google Cloud Functions (Serverless)
 :extension-status: preview
 include::_attributes.adoc[]
-:categories: cloud
 :summary: This guide explains how you can deploy Quarkus-based Google Cloud Functions.
 :topics: google,gcp,serverless,function,cloud
 :extensions: io.quarkus:quarkus-google-cloud-functions

--- a/docs/src/main/asciidoc/getting-started-dev-services.adoc
+++ b/docs/src/main/asciidoc/getting-started-dev-services.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Your second Quarkus application
 include::_attributes.adoc[]
 :diataxis-type: tutorial
-:categories: getting-started, data, core
 :summary: Discover some of the features that make developing with Quarkus a joyful experience.
 :topics: getting-started,dev-services
 

--- a/docs/src/main/asciidoc/getting-started-reactive.adoc
+++ b/docs/src/main/asciidoc/getting-started-reactive.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Getting Started With Reactive
 include::_attributes.adoc[]
-:categories: getting-started,reactive
 :summary: Learn more about developing reactive applications with Quarkus.
 :topics: getting-started,reactive
 

--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 [id="testing"]
 = Testing Your Application
 include::_attributes.adoc[]
-:categories: core, native, tooling
 :summary: This guide covers testing in JVM mode, native mode, and injection of resources into tests
 :numbered:
 :sectnums:

--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Creating Your First Application
 include::_attributes.adoc[]
-:categories: getting-started
 :summary: Build a REST API with live reload, dependency injection, and tests, in under 15 minutes.
 :numbered:
 :sectnums:

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 [id="gradle-tooling"]
 = Quarkus and Gradle
 include::_attributes.adoc[]
-:categories: tooling, native
 :summary: Develop and build your Quarkus application with Gradle
 :devtools-no-maven:
 :topics: gradle,tooling

--- a/docs/src/main/asciidoc/grpc-cli.adoc
+++ b/docs/src/main/asciidoc/grpc-cli.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using gRPC CLI
 include::_attributes.adoc[]
-:categories: serialization
 :summary: This page explains how to use gRPC CLI.
 :topics: grpc,cli
 :extensions: io.quarkus:quarkus-grpc-cli

--- a/docs/src/main/asciidoc/grpc-generation-reference.adoc
+++ b/docs/src/main/asciidoc/grpc-generation-reference.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = gRPC code generation reference guide
 include::_attributes.adoc[]
-:categories: Serialization
 :diataxis-type: Reference
 :summary: Learn how to configure gRPC code generation.
 :topics: grpc

--- a/docs/src/main/asciidoc/grpc-getting-started.adoc
+++ b/docs/src/main/asciidoc/grpc-getting-started.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Getting Started with gRPC
 include::_attributes.adoc[]
-:categories: serialization
 :summary: This guide explains how to start using gRPC in your Quarkus application.
 :topics: grpc
 :extensions: io.quarkus:quarkus-grpc

--- a/docs/src/main/asciidoc/grpc-kubernetes.adoc
+++ b/docs/src/main/asciidoc/grpc-kubernetes.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Deploying your gRPC Service in Kubernetes
 include::_attributes.adoc[]
-:categories: serialization
 :summary: This guide explains how to deploy your gRPC services in Quarkus to Kubernetes.
 :topics: grpc,kubernetes
 :extensions: io.quarkus:quarkus-grpc,io.quarkus:quarkus-kubernetes

--- a/docs/src/main/asciidoc/grpc-reference.adoc
+++ b/docs/src/main/asciidoc/grpc-reference.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = gRPC reference guide
 include::_attributes.adoc[]
-:categories: Serialization
 :diataxis-type: Reference
 :summary: Learn how to configure gRPC server and clients.
 :topics: grpc

--- a/docs/src/main/asciidoc/grpc-service-consumption.adoc
+++ b/docs/src/main/asciidoc/grpc-service-consumption.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Consuming a gRPC Service
 include::_attributes.adoc[]
-:categories: serialization
 :summary: This guide explains how to consume gRPC services in your Quarkus application.
 :topics: grpc
 :extensions: io.quarkus:quarkus-grpc

--- a/docs/src/main/asciidoc/grpc-service-implementation.adoc
+++ b/docs/src/main/asciidoc/grpc-service-implementation.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Implementing a gRPC Service
 include::_attributes.adoc[]
-:categories: serialization
 :summary: This guide explains how to implement gRPC services in your Quarkus application.
 :topics: grpc
 :extensions: io.quarkus:quarkus-grpc

--- a/docs/src/main/asciidoc/grpc-xds.adoc
+++ b/docs/src/main/asciidoc/grpc-xds.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using xDS gRPC
 include::_attributes.adoc[]
-:categories: serialization
 :summary: This page explains how to enable xDS gRPC usage in your Quarkus application.
 :topics: grpc,xds
 :extensions: io.quarkus:quarkus-grpc-xds

--- a/docs/src/main/asciidoc/grpc.adoc
+++ b/docs/src/main/asciidoc/grpc.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = gRPC
 include::_attributes.adoc[]
-:categories: serialization
 :summary: Entry point for everything gRPC.
 :topics: grpc
 :extensions: io.quarkus:quarkus-grpc,io.quarkus:quarkus-grpc-xds

--- a/docs/src/main/asciidoc/hibernate-orm-panache-kotlin.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache-kotlin.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Simplified Hibernate ORM with Panache and Kotlin
 include::_attributes.adoc[]
-:categories: data, alt-languages
 :summary: This explains the specifics of using Hibernate ORM with Panache in a Kotlin project.
 :config-file: application.properties
 :topics: data,hibernate-orm,panache,kotlin,sql,jdbc

--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Simplified Hibernate ORM with Panache
 include::_attributes.adoc[]
-:categories: data
 :summary: Hibernate ORM is the de facto Jakarta Persistence implementation and offers you the full breadth of an Object Relational Mapper. It makes complex mappings possible, but it does not make simple and common mappings trivial. Panache focuses on making your entities trivial and fun to write.
 :config-file: application.properties
 :topics: data,hibernate-orm,panache,sql,jdbc

--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Hibernate ORM and Jakarta Persistence
 include::_attributes.adoc[]
-:categories: data
 :summary: Hibernate ORM is the de facto Jakarta Persistence implementation and offers you the full breadth of an Object Relational Mapper. It works beautifully in Quarkus.
 :config-file: application.properties
 :topics: data,hibernate-orm,sql,jdbc

--- a/docs/src/main/asciidoc/hibernate-reactive-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-reactive-panache.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Simplified Hibernate Reactive with Panache
 include::_attributes.adoc[]
-:categories: data
 :summary: Simplified reactive ORM layer based on Hibernate Reactive.
 :config-file: application.properties
 :topics: data,hibernate-reactive,panache,sql

--- a/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Use Hibernate Search with Hibernate ORM and Elasticsearch/OpenSearch
 include::_attributes.adoc[]
-:categories: data
 :summary: Hibernate Search with Hibernate ORM allows you to index your entities in an Elasticsearch/OpenSearch cluster and easily offer full text search in all your Hibernate ORM-based applications.
 :keywords: elasticsearch opensearch hibernate orm search
 :topics: data,hibernate-search,elasticsearch,opensearch,search,nosql,hibernate-orm

--- a/docs/src/main/asciidoc/hibernate-search-standalone-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-standalone-elasticsearch.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Use Hibernate Search in Standalone mode with Elasticsearch/OpenSearch
 include::_attributes.adoc[]
-:categories: data
 :summary: Hibernate Search Standalone allows you to index your entities in an Elasticsearch/OpenSearch cluster and easily offer full text search in all your applications, even without Hibernate ORM.
 :keywords: elasticsearch opensearch hibernate search
 :topics: data,hibernate-search,elasticsearch,opensearch,search,nosql

--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = HTTP Reference
 include::_attributes.adoc[]
-:categories: web
 :summary: Learn more about configuring Quarkus' Vert.x based HTTP layer - and Undertow if you are using servlets.
 :numbered:
 :sectnums:

--- a/docs/src/main/asciidoc/ide-tooling.adoc
+++ b/docs/src/main/asciidoc/ide-tooling.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus Tools in your favorite IDE
 include::_attributes.adoc[]
-:categories: getting-started
 :summary: Learn more about Quarkus integrations in IDEs.
 :topics: ide,tooling
 

--- a/docs/src/main/asciidoc/infinispan-client-reference.adoc
+++ b/docs/src/main/asciidoc/infinispan-client-reference.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Infinispan Client Extension Reference Guide
 include::_attributes.adoc[]
-:categories: data
 :summary: Infinispan is an in memory distributed data store and cache server that offers flexible deployment options and robust capabilities for storing, managing, and processing data.
 :topics: data,infinispan
 :extensions: io.quarkus:quarkus-infinispan-client

--- a/docs/src/main/asciidoc/infinispan-client.adoc
+++ b/docs/src/main/asciidoc/infinispan-client.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using the Infinispan Client
 include::_attributes.adoc[]
-:categories: data
 :summary: This guide covers how to use Infinispan with Quarkus.
 :topics: data,infinispan
 :extensions: io.quarkus:quarkus-infinispan-client

--- a/docs/src/main/asciidoc/infinispan-dev-services.adoc
+++ b/docs/src/main/asciidoc/infinispan-dev-services.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Dev Services for Infinispan
 include::_attributes.adoc[]
-:categories: data
 :summary: Start Infinispan automatically in dev and test modes.
 :topics: dev-services,data,infinispan,testing,dev-mode
 :extensions: io.quarkus:quarkus-infinispan-client

--- a/docs/src/main/asciidoc/info.adoc
+++ b/docs/src/main/asciidoc/info.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Application Info Endpoint
 include::_attributes.adoc[]
-:categories: observability
 :summary: Expose build, git, Java, and OS information via the /q/info endpoint.
 :topics: info,observability
 :extensions: io.quarkus:quarkus-info

--- a/docs/src/main/asciidoc/init-tasks.adoc
+++ b/docs/src/main/asciidoc/init-tasks.adoc
@@ -4,7 +4,6 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Initialization tasks
-:categories: initialization
 :summary: This reference guide explains how to configure initialization tasks
 :topics: init,kubernetes,openshift,liquibase,flyway
 :extensions: io.quarkus:quarkus-kubernetes,io.quarkus:quarkus-openshift,io.quarkus:quarkus-flyway,io.quarkus:quarkus-liquibase

--- a/docs/src/main/asciidoc/jar-tree-shaking.adoc
+++ b/docs/src/main/asciidoc/jar-tree-shaking.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Tree-shaking JAR dependencies
 include::_attributes.adoc[]
-:categories: core
 :summary: This guide explains how to reduce JAR size by removing unreachable classes from runtime dependencies.
 :topics: packaging,jar,tree-shaking,optimization
 

--- a/docs/src/main/asciidoc/jfr.adoc
+++ b/docs/src/main/asciidoc/jfr.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 [id="jfr"]
 = Using JDK Flight Recorder
 include::_attributes.adoc[]
-:categories: observability
 :summary: This guide explains how JDK Flight Recorder (JFR) can be extended to provide additional insight into your Quarkus application.
 :topics: observability,jfr
 :extensions: io.quarkus:quarkus-jfr

--- a/docs/src/main/asciidoc/jlink.adoc
+++ b/docs/src/main/asciidoc/jlink.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = JLink packaging
 include::_attributes.adoc[]
 :diataxis-type: reference
-:categories: packaging
 :extension-status: experimental
 :summary: The jlink extension produces a custom Java runtime image containing only the modules needed to run the application.
 :topics: jlink,packaging,modules,modularity

--- a/docs/src/main/asciidoc/jms.adoc
+++ b/docs/src/main/asciidoc/jms.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using JMS
 include::_attributes.adoc[]
-:categories: messaging
 :summary: This guide demonstrates how your Quarkus application can use JMS messaging with AMQP 1.0 using Apache Qpid JMS, or using Apache ActiveMQ Artemis JMS.
 :extension-status: preview
 :topics: messaging,jms,artemis,qpid,activemq

--- a/docs/src/main/asciidoc/jreleaser.adoc
+++ b/docs/src/main/asciidoc/jreleaser.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Packaging And Releasing With JReleaser
 include::_attributes.adoc[]
-:categories: tooling
 :jreleaser-version: 1.6.0
 :numbered:
 :sectnums:

--- a/docs/src/main/asciidoc/kafka-dev-services.adoc
+++ b/docs/src/main/asciidoc/kafka-dev-services.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Dev Services for Kafka
 include::_attributes.adoc[]
-:categories: messaging
 :summary: Start Apache Kafka automatically in dev and test modes.
 :topics: messaging,kafka,dev-services,testing,dev-mode
 :extensions: io.quarkus:quarkus-kafka-client,io.quarkus:quarkus-messaging-kafka

--- a/docs/src/main/asciidoc/kafka-dev-ui.adoc
+++ b/docs/src/main/asciidoc/kafka-dev-ui.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Kafka Dev UI
 include::_attributes.adoc[]
-:categories: messaging
 :summary: Dev UI extension for Apache Kafka for development purposes.
 :topics: messaging,kafka,dev-ui,dev-mode
 :extensions: io.quarkus:quarkus-kafka-client,io.quarkus:quarkus-messaging-kafka

--- a/docs/src/main/asciidoc/kafka-getting-started.adoc
+++ b/docs/src/main/asciidoc/kafka-getting-started.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Getting Started with Quarkus Messaging and Apache Kafka
 include::_attributes.adoc[]
-:categories: messaging
 :summary: Build two applications that communicate via Apache Kafka using Quarkus Messaging.
 :topics: messaging,kafka,reactive-messaging
 :extensions: io.quarkus:quarkus-messaging-kafka

--- a/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
+++ b/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Apache Kafka with Schema Registry and Avro
 include::_attributes.adoc[]
-:categories: messaging
 :summary: Use Apache Kafka, Avro serialized records, and connect to a schema registry.
 :topics: messaging,kafka,apicurio,registry
 :extensions: io.quarkus:quarkus-apicurio-registry-avro,io.quarkus:quarkus-messaging-kafka

--- a/docs/src/main/asciidoc/kafka-schema-registry-json-schema.adoc
+++ b/docs/src/main/asciidoc/kafka-schema-registry-json-schema.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Apache Kafka with Schema Registry and JSON Schema
 include::_attributes.adoc[]
-:categories: messaging
 :summary: Use Apache Kafka, Json Schema serialized records, and connect to a schema registry.
 :topics: messaging,kafka,apicurio,registry
 :extensions: io.quarkus:quarkus-apicurio-registry-json-schema,io.quarkus:quarkus-messaging-kafka

--- a/docs/src/main/asciidoc/kafka-streams.adoc
+++ b/docs/src/main/asciidoc/kafka-streams.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Apache Kafka Streams
 include::_attributes.adoc[]
-:categories: messaging
 :summary: This guide demonstrates how your Quarkus application can utilize the Apache Kafka Streams API to implement stream processing applications based on Apache Kafka.
 :topics: messaging,kafka,kafka-streams
 :extensions: io.quarkus:quarkus-kafka-streams

--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Apache Kafka Reference Guide
 include::_attributes.adoc[]
-:categories: messaging
 :summary: This reference guide provides an in-depth look on Apache Kafka and Quarkus Messaging extensions.
 :numbered:
 :sectnums:

--- a/docs/src/main/asciidoc/kotlin.adoc
+++ b/docs/src/main/asciidoc/kotlin.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Kotlin
 include::_attributes.adoc[]
-:categories: alt-languages
 :summary: This guide explains how to use Kotlin.
 :topics: kotlin
 :extensions: io.quarkus:quarkus-kotlin

--- a/docs/src/main/asciidoc/kubernetes-client.adoc
+++ b/docs/src/main/asciidoc/kubernetes-client.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Kubernetes Client
 include::_attributes.adoc[]
-:categories: cloud
 :summary: This guide demonstrates how to use the Fabric8 Kubernetes client to interact with your Kubernetes cluster.
 :topics: kubernetes,openshift,kubernetes-client
 :extensions: io.quarkus:quarkus-kubernetes-client

--- a/docs/src/main/asciidoc/kubernetes-config.adoc
+++ b/docs/src/main/asciidoc/kubernetes-config.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Kubernetes Config
 include::_attributes.adoc[]
-:categories: cloud
 :summary: Use ConfigMaps as a configuration source for your Quarkus applications.
 :topics: kubernetes,openshift,configuration,configmap
 :extensions: io.quarkus:quarkus-kubernetes-config

--- a/docs/src/main/asciidoc/kubernetes-dev-services.adoc
+++ b/docs/src/main/asciidoc/kubernetes-dev-services.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Dev Services for Kubernetes
 include::_attributes.adoc[]
-:categories: cloud
 :summary: Start a Kubernetes API server automatically in dev and test modes.
 :topics: dev-services,kubernetes,testing,dev-mode
 :extensions: io.quarkus:quarkus-kubernetes-client

--- a/docs/src/main/asciidoc/lifecycle.adoc
+++ b/docs/src/main/asciidoc/lifecycle.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Application Initialization and Termination
 include::_attributes.adoc[]
-:categories: core
 :keywords: lifecycle event
 :summary: You often need to execute custom actions when the application starts and clean up everything when the application stops. This guide explains how to be notified when an application stops or starts.
 :topics: lifecycle,observers

--- a/docs/src/main/asciidoc/liquibase-mongodb.adoc
+++ b/docs/src/main/asciidoc/liquibase-mongodb.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Liquibase MongoDB
 include::_attributes.adoc[]
-:categories: data
 :change-log: src/main/resources/db/changeLog.xml
 :config-file: application.properties
 :topics: data,schema-migration,liquibase,mongodb

--- a/docs/src/main/asciidoc/liquibase.adoc
+++ b/docs/src/main/asciidoc/liquibase.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Liquibase
 include::_attributes.adoc[]
-:categories: data
 :summary: This guide covers how to use the Liquibase extension to manage your schema migrations.
 :change-log: src/main/resources/db/changeLog.xml
 :config-file: application.properties

--- a/docs/src/main/asciidoc/load-shedding-reference.adoc
+++ b/docs/src/main/asciidoc/load-shedding-reference.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 include::_attributes.adoc[]
 :numbered:
 :sectnums:
-:categories: web
 :topics: web,load-shedding
 :extensions: io.quarkus:quarkus-load-shedding
 :extension-status: experimental

--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 [id="logging"]
 = Logging configuration
 include::_attributes.adoc[]
-:categories: core,getting-started,observability
 :diataxis-type: reference
 :topics: logging,observability
 :toclevels: 4

--- a/docs/src/main/asciidoc/lra-dev-services.adoc
+++ b/docs/src/main/asciidoc/lra-dev-services.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Dev Services for LRA
 include::_attributes.adoc[]
-:categories: data
 :summary: Start the Narayana LRA coordinator automatically in dev and test modes.
 :topics: data,lra,narayana
 :extensions: io.quarkus:quarkus-narayana-lra

--- a/docs/src/main/asciidoc/lra.adoc
+++ b/docs/src/main/asciidoc/lra.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Narayana LRA Participant Support
 include::_attributes.adoc[]
-:categories: data
 :summary: This guides covers the usage of LRA to coordinate activities across services.
 :topics: data,lra,narayana
 :extensions: io.quarkus:quarkus-narayana-lra

--- a/docs/src/main/asciidoc/mailer-reference.adoc
+++ b/docs/src/main/asciidoc/mailer-reference.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Mailer Reference Guide
 include::_attributes.adoc[]
-:categories: miscellaneous
 :summary: This reference guide explains in more details the configuration and usage of the Quarkus Mailer.
 :topics: mail,mailer
 :extensions: io.quarkus:quarkus-mailer

--- a/docs/src/main/asciidoc/mailer.adoc
+++ b/docs/src/main/asciidoc/mailer.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Sending emails using SMTP
 include::_attributes.adoc[]
-:categories: miscellaneous
 :summary: Learn more about how you can send email from a Quarkus application with our reactive email client.
 :topics: mail,mailer
 :extensions: io.quarkus:quarkus-mailer

--- a/docs/src/main/asciidoc/management-interface-reference.adoc
+++ b/docs/src/main/asciidoc/management-interface-reference.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Management interface reference
 include::_attributes.adoc[]
-:categories: observability
 :summary: Management interface configuration
 :numbered:
 :sectnums:

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 [id="maven-tooling"]
 = Quarkus and Maven
 include::_attributes.adoc[]
-:categories: tooling, native
 :summary: Develop and build your Quarkus application with Maven
 :devtools-no-gradle:
 :topics: maven,tooling

--- a/docs/src/main/asciidoc/messaging-virtual-threads.adoc
+++ b/docs/src/main/asciidoc/messaging-virtual-threads.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus Virtual Thread support with Reactive Messaging
 include::_attributes.adoc[]
-:categories: messaging
 :topics: messaging,kafka,reactive-messaging,virtual-threads
 :extensions: io.quarkus:quarkus-messaging-kafka
 :runonvthread: https://javadoc.io/doc/io.smallrye.common/smallrye-common-annotation/latest/io/smallrye/common/annotation/RunOnVirtualThread.html

--- a/docs/src/main/asciidoc/messaging.adoc
+++ b/docs/src/main/asciidoc/messaging.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus Messaging Extensions
 include::_attributes.adoc[]
-:categories: messaging
 :topics: messaging,reactive-messaging
 :extensions: io.quarkus:quarkus-messaging
 :rm_blocking_annotation: https://javadoc.io/doc/io.smallrye.reactive/smallrye-reactive-messaging-api/latest/io/smallrye/reactive/messaging/annotations/Blocking.html

--- a/docs/src/main/asciidoc/modularity-reference.adoc
+++ b/docs/src/main/asciidoc/modularity-reference.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Modularity SPI reference
 include::_attributes.adoc[]
 :diataxis-type: reference
-:categories: architecture
 :extension-status: experimental
 :summary: Reference for the build items that Quarkus extensions use to participate in Quarkus modularity.
 :topics: modularity,jpms,modules,extensions,spi

--- a/docs/src/main/asciidoc/modularity.adoc
+++ b/docs/src/main/asciidoc/modularity.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Quarkus modularity
 include::_attributes.adoc[]
 :diataxis-type: concept
-:categories: architecture
 :extension-status: experimental
 :summary: Quarkus modularity builds on JPMS to produce a complete and enhanced module graph for the application at build time.
 :topics: modularity,jpms,modules,extensions

--- a/docs/src/main/asciidoc/mongodb-panache-kotlin.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache-kotlin.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Simplified MongoDB with Panache and Kotlin
 include::_attributes.adoc[]
-:categories: data, alt-languages
 :summary: This guide covers the usage of MongoDB using active records and repositories in a Kotlin project.
 :config-file: application.properties
 :topics: data,mongodb,nosql,panache,kotlin

--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Simplified MongoDB with Panache
 include::_attributes.adoc[]
-:categories: data
 :summary: This guide covers the usage of MongoDB using active records and repositories.
 :config-file: application.properties
 :mongodb-doc-root-url: https://www.mongodb.com/docs/drivers/java/sync/current

--- a/docs/src/main/asciidoc/mongodb.adoc
+++ b/docs/src/main/asciidoc/mongodb.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using the MongoDB Client
 include::_attributes.adoc[]
-:categories: data
 :summary: This guide covers how to use MongoDB in Quarkus.
 :topics: data,mongodb,nosql
 :extensions: io.quarkus:quarkus-mongodb-client

--- a/docs/src/main/asciidoc/mutiny-primer.adoc
+++ b/docs/src/main/asciidoc/mutiny-primer.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Mutiny - Async for mere mortals
 include::_attributes.adoc[]
-:categories: reactive
 :topics: mutiny,reactive
 :extensions: io.quarkus:quarkus-mutiny
 

--- a/docs/src/main/asciidoc/native-and-ssl.adoc
+++ b/docs/src/main/asciidoc/native-and-ssl.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using SSL With Native Executables
 include::_attributes.adoc[]
-:categories: core, native, security
 :summary: In this guide, we will discuss how you can get your native images to support SSL, as native images don't support it out of the box.
 :devtools-no-gradle:
 :topics: native,ssl

--- a/docs/src/main/asciidoc/native-reference.adoc
+++ b/docs/src/main/asciidoc/native-reference.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 [id="native-reference"]
 = Native Reference Guide
 include::_attributes.adoc[]
-:categories: native
 :topics: native
 
 This guide is a companion to the

--- a/docs/src/main/asciidoc/observability-devservices-lgtm.adoc
+++ b/docs/src/main/asciidoc/observability-devservices-lgtm.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Observability Dev Services with Grafana OTel LGTM
 include::_attributes.adoc[]
-:categories: observability,devservices,telemetry,metrics,tracing,logging, opentelemetry, micrometer, prometheus, tempo, loki, grafana
 :summary: Instructions on how to use Grafana Otel LGTM
 :topics: observability,grafana,lgtm,otlp,opentelemetry,devservices,micrometer
 :extensions: io.quarkus:quarkus-observability-devservices

--- a/docs/src/main/asciidoc/observability-devservices.adoc
+++ b/docs/src/main/asciidoc/observability-devservices.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Observability Dev Services
 include::_attributes.adoc[]
-:categories: observability,devservices,telemetry,metrics,tracing,logging
 :summary: Entry point for Observability DevServices
 :topics: observability,grafana,lgtm,prometheus,victoriametrics,jaeger,otel,otlp
 :extensions: io.quarkus:quarkus-observability-devservices

--- a/docs/src/main/asciidoc/observability.adoc
+++ b/docs/src/main/asciidoc/observability.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Observability in Quarkus
 include::_attributes.adoc[]
 :diataxis-type: reference
-:categories: observability
 :summary: This guide explains how your Quarkus application can utilize OpenTelemetry to provide observability for interactive web applications.
 :topics: observability,opentelemetry, micrometer, jfr, logging, metrics, tracing, monitoring, devservice
 :extensions: io.quarkus:quarkus-opentelemetry,io.quarkus:quarkus-micrometer,io.quarkus:quarkus-jfr

--- a/docs/src/main/asciidoc/openapi-swaggerui.adoc
+++ b/docs/src/main/asciidoc/openapi-swaggerui.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using OpenAPI and Swagger UI
 include::_attributes.adoc[]
-:categories: web
 :summary: This guide explains how to use the OpenAPI extension to generate an OpenAPI descriptor and get a Swagger UI frontend to test your REST endpoints.
 :topics: rest,openapi,swagger-ui,dev-ui
 :extensions: io.quarkus:quarkus-smallrye-openapi

--- a/docs/src/main/asciidoc/opentelemetry-logging.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-logging.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Using OpenTelemetry Logging
 include::_attributes.adoc[]
 :extension-status: preview
-:categories: observability
 :summary: This guide explains how your Quarkus application can utilize OpenTelemetry Logging to provide centralised logging for interactive web applications.
 :topics: observability,opentelemetry,logging
 :extensions: io.quarkus:quarkus-opentelemetry

--- a/docs/src/main/asciidoc/opentelemetry-metrics.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-metrics.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Using OpenTelemetry Metrics
 include::_attributes.adoc[]
 :extension-status: preview
-:categories: observability
 :summary: This guide explains how your Quarkus application can utilize OpenTelemetry to provide metrics for interactive web applications.
 :topics: observability,opentelemetry,metrics
 :extensions: io.quarkus:quarkus-opentelemetry

--- a/docs/src/main/asciidoc/opentelemetry-tracing.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-tracing.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using OpenTelemetry Tracing
 include::_attributes.adoc[]
-:categories: observability
 :summary: This guide explains how your Quarkus application can utilize OpenTelemetry Tracing to provide distributed tracing for interactive web applications.
 :topics: observability,opentelemetry,tracing
 :extensions: io.quarkus:quarkus-opentelemetry

--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Using OpenTelemetry
 include::_attributes.adoc[]
 :diataxis-type: reference
-:categories: observability
 :summary: This guide explains how your Quarkus application can utilize OpenTelemetry to provide observability for interactive web applications.
 :topics: observability,opentelemetry
 :extensions: io.quarkus:quarkus-opentelemetry

--- a/docs/src/main/asciidoc/performance-measure.adoc
+++ b/docs/src/main/asciidoc/performance-measure.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Measuring Performance
 include::_attributes.adoc[]
-:categories: miscellaneous
 :summary: This guide explains how to best measure the footprint of a Quarkus application.
 :topics: internals,performance
 

--- a/docs/src/main/asciidoc/picocli.adoc
+++ b/docs/src/main/asciidoc/picocli.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Command Mode with Picocli
 include::_attributes.adoc[]
-:categories: command-line
 :summary: Simplify command line applications creation with the Picocli extension.
 :topics: command-line,cli,picocli
 :extensions: io.quarkus:quarkus-picocli

--- a/docs/src/main/asciidoc/platform.adoc
+++ b/docs/src/main/asciidoc/platform.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Platform
 include::_attributes.adoc[]
-:categories: architecture
 :summary: Learn more about what we call a Platform in the Quarkus world.
 :topics: internals,platform
 

--- a/docs/src/main/asciidoc/podman.adoc
+++ b/docs/src/main/asciidoc/podman.adoc
@@ -4,7 +4,6 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Podman with Quarkus
-:categories: tooling
 :topics: podman,devops,tooling
 include::_attributes.adoc[]
 

--- a/docs/src/main/asciidoc/proxy-registry.adoc
+++ b/docs/src/main/asciidoc/proxy-registry.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Using Proxy Registry
 :extension-status: preview
 include::_attributes.adoc[]
-:categories: miscellaneous
 :summary: This guide explains how to use the Proxy Registry in your Quarkus application.
 :topics: security,proxy,http
 :extensions: io.quarkus:quarkus-proxy-registry

--- a/docs/src/main/asciidoc/pulsar-dev-services.adoc
+++ b/docs/src/main/asciidoc/pulsar-dev-services.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Dev Services for Pulsar
 include::_attributes.adoc[]
-:categories: messaging
 :topics: messaging,reactive-messaging,pulsar,dev-services,testing,dev-mode
 :extensions: io.quarkus:quarkus-messaging-pulsar
 

--- a/docs/src/main/asciidoc/pulsar-getting-started.adoc
+++ b/docs/src/main/asciidoc/pulsar-getting-started.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Getting Started to Quarkus Messaging with Apache Pulsar
 include::_attributes.adoc[]
-:categories: messaging
 :topics: messaging,reactive-messaging,pulsar
 :extensions: io.quarkus:quarkus-messaging-pulsar
 :summary: This guide demonstrates how your Quarkus application can utilize Quarkus Messaging to interact with Apache Pulsar.

--- a/docs/src/main/asciidoc/pulsar.adoc
+++ b/docs/src/main/asciidoc/pulsar.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Apache Pulsar Reference Guide
 include::_attributes.adoc[]
-:categories: messaging
 :summary: This reference guide provides an in-depth look on Apache Pulsar and the Quarkus Messaging extensions.
 :numbered:
 :sectnums:

--- a/docs/src/main/asciidoc/quarkus-data-hibernate.adoc
+++ b/docs/src/main/asciidoc/quarkus-data-hibernate.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Simplified Hibernate with Quarkus Data Hibernate
 include::_attributes.adoc[]
-:categories: data
 :summary: Hibernate is the de facto Jakarta Persistence implementation and offers you the full breadth of an Object Relational Mapper. It makes complex mappings possible, but it does not make simple and common mappings trivial. Quarkus Data Hibernate focuses on making your entities trivial and fun to write.
 :config-file: application.properties
 :topics: data,hibernate-orm,hibernate-reactive,panache,sql,jdbc

--- a/docs/src/main/asciidoc/quarkus-maven-plugin.adoc
+++ b/docs/src/main/asciidoc/quarkus-maven-plugin.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 include::_attributes.adoc[]
 :topics: maven,tooling
 :diataxis-type: reference
-:categories: tooling
 
 The Quarkus Maven Plugin builds the Quarkus applications, and provides helpers to launch dev mode or build native executables.
 For more information about how to use the Quarkus Maven Plugin, please refer to the xref:maven-tooling.adoc[Maven Tooling guide].

--- a/docs/src/main/asciidoc/quarkus-reactive-architecture.adoc
+++ b/docs/src/main/asciidoc/quarkus-reactive-architecture.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus Reactive Architecture
 include::_attributes.adoc[]
-:categories: architecture
 :summary: Learn more about Quarkus reactive architecture.
 :topics: internals,reactive
 

--- a/docs/src/main/asciidoc/quarkus-runtime-base-image.adoc
+++ b/docs/src/main/asciidoc/quarkus-runtime-base-image.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus Base Runtime Image
 include::_attributes.adoc[]
-:categories: tooling
 :topics: docker,podman,images
 
 To ease the containerization of native executables, Quarkus provides a base image providing the requirements to run these executables.

--- a/docs/src/main/asciidoc/quartz.adoc
+++ b/docs/src/main/asciidoc/quartz.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Scheduling Periodic Tasks with Quartz
 include::_attributes.adoc[]
-:categories: miscellaneous
 :summary: You need clustering support for your scheduled tasks? This guide explains how to use the Quartz extension for that.
 :topics: scheduling,cronjob,quartz
 :extensions: io.quarkus:quarkus-quartz

--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Qute Reference Guide
 include::_attributes.adoc[]
-:categories: miscellaneous
 :summary: Learn everything you need to know about the Qute template engine.
 :numbered:
 :sectnums:

--- a/docs/src/main/asciidoc/qute.adoc
+++ b/docs/src/main/asciidoc/qute.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Qute Templating Engine
 include::_attributes.adoc[]
-:categories: miscellaneous
 :summary: Learn more about how you can use templating in your applications with the Qute template engine.
 :topics: templating,qute
 :extensions: io.quarkus:quarkus-qute,io.quarkus:quarkus-resteasy-qute,io.quarkus:quarkus-rest-qute

--- a/docs/src/main/asciidoc/rabbitmq-dev-services.adoc
+++ b/docs/src/main/asciidoc/rabbitmq-dev-services.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Dev Services for RabbitMQ
 include::_attributes.adoc[]
-:categories: messaging
 :topics: messaging,reactive-messaging,rabbitmq,dev-services,testing,dev-mode
 :extensions: io.quarkus:quarkus-messaging-rabbitmq
 

--- a/docs/src/main/asciidoc/rabbitmq-reference.adoc
+++ b/docs/src/main/asciidoc/rabbitmq-reference.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Reactive Messaging RabbitMQ Connector Reference Documentation
 include::_attributes.adoc[]
 :extension-status: preview
-:categories: messaging
 :topics: messaging,reactive-messaging,rabbitmq,dev-services,testing,dev-mode
 :extensions: io.quarkus:quarkus-messaging-rabbitmq
 

--- a/docs/src/main/asciidoc/rabbitmq.adoc
+++ b/docs/src/main/asciidoc/rabbitmq.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Getting Started to Quarkus Messaging with RabbitMQ
 :extension-status: preview
 include::_attributes.adoc[]
-:categories: messaging
 :topics: messaging,reactive-messaging,rabbitmq
 :extensions: io.quarkus:quarkus-messaging-rabbitmq
 

--- a/docs/src/main/asciidoc/reactive-event-bus.adoc
+++ b/docs/src/main/asciidoc/reactive-event-bus.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using the event bus
 include::_attributes.adoc[]
-:categories: messaging
 :keywords: vertx vert.x
 :summary: This guide explains how different beans can interact using the event bus.
 :topics: messaging,event-bus,vert.x

--- a/docs/src/main/asciidoc/reactive-routes.adoc
+++ b/docs/src/main/asciidoc/reactive-routes.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Reactive Routes
 include::_attributes.adoc[]
-:categories: web
 :summary: This guide demonstrates how to use reactive routes.
 :topics: http,web,routing
 :extensions: io.quarkus:quarkus-reactive-routes

--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Reactive SQL Clients
 include::_attributes.adoc[]
-:categories: data
 :summary: This guide covers how to use the Reactive SQL Clients in Quarkus.
 :config-file: application.properties
 :topics: data,database,reactive,sql

--- a/docs/src/main/asciidoc/reaugmentation.adoc
+++ b/docs/src/main/asciidoc/reaugmentation.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Re-augment a Quarkus Application
 include::_attributes.adoc[]
-:categories: tooling
 :summary: Use mutable jars to rebuild your application with different build time configurations.
 :topics: mutable-jars,tooling
 

--- a/docs/src/main/asciidoc/redis-dev-services.adoc
+++ b/docs/src/main/asciidoc/redis-dev-services.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Dev Services for Redis
 :extension-status: stable
 include::_attributes.adoc[]
-:categories: data
 :summary: Start Redis automatically in dev and test modes.
 :topics: data,redis,nosql,dev-services,testing,dev-mode
 :extensions: io.quarkus:quarkus-redis-client

--- a/docs/src/main/asciidoc/redis-reference.adoc
+++ b/docs/src/main/asciidoc/redis-reference.adoc
@@ -8,7 +8,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 include::_attributes.adoc[]
 :numbered:
 :sectnums:
-:categories: data
 :topics: data,redis,nosql
 :extensions: io.quarkus:quarkus-redis-client
 

--- a/docs/src/main/asciidoc/redis.adoc
+++ b/docs/src/main/asciidoc/redis.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Using the Redis Client
 :extension-status: stable
 include::_attributes.adoc[]
-:categories: data
 :topics: data,redis,nosql
 :extensions: io.quarkus:quarkus-redis-client
 :summary: This guide covers how to use a Redis datastore in Quarkus.

--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using the REST Client
 include::_attributes.adoc[]
-:categories: web
 :summary: This guide explains how to use the REST Client.
 :topics: rest,rest-client,resteasy-reactive
 :extensions: io.quarkus:quarkus-rest-client,io.quarkus:quarkus-rest-client-jackson,io.quarkus:quarkus-rest-client-jsonb

--- a/docs/src/main/asciidoc/rest-data-panache.adoc
+++ b/docs/src/main/asciidoc/rest-data-panache.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Generating Jakarta REST resources with Panache
 include::_attributes.adoc[]
-:categories: web
 :summary: Hibernate ORM REST Data with Panache simplifies the creation of CRUD applications based on Jakarta REST and Hibernate ORM.
 :topics: rest,hibernate-orm,panache,mongodb,sql,jdbc,nosql
 :extensions: io.quarkus:quarkus-hibernate-orm-rest-data-panache,io.quarkus:quarkus-hibernate-reactive-rest-data-panache,io.quarkus:quarkus-mongodb-rest-data-panache

--- a/docs/src/main/asciidoc/rest-json.adoc
+++ b/docs/src/main/asciidoc/rest-json.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Writing JSON REST Services
 include::_attributes.adoc[]
-:categories: web, serialization
 :summary: JSON is now the lingua franca between microservices. In this guide, we see how you can get your REST services to consume and produce JSON payloads.
 :topics: rest,json,resteasy-reactive
 :extensions: io.quarkus:quarkus-rest-jackson,io.quarkus:quarkus-rest-jsonb,io.quarkus:quarkus-rest

--- a/docs/src/main/asciidoc/rest-migration.adoc
+++ b/docs/src/main/asciidoc/rest-migration.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Migrating to Quarkus REST (formerly RESTEasy Reactive)
 include::_attributes.adoc[]
-:categories: web
 :topics: rest,rest-client,resteasy-reactive
 :extensions: io.quarkus:quarkus-rest,io.quarkus:quarkus-rest-jackson,io.quarkus:quarkus-rest-jsonb,io.quarkus:quarkus-rest-client,io.quarkus:quarkus-rest-client-jackson,io.quarkus:quarkus-rest-client-jsonb
 

--- a/docs/src/main/asciidoc/rest-virtual-threads.adoc
+++ b/docs/src/main/asciidoc/rest-virtual-threads.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Use virtual threads in REST applications
 include::_attributes.adoc[]
 :diataxis-type: howto
-:categories: web, core
 :summary: How to use virtual threads in a REST application
 :topics: rest,resteasy-reactive,virtual-threads
 :extensions: io.quarkus:quarkus-rest,io.quarkus:quarkus-rest-jackson,io.quarkus:quarkus-rest-jsonb,io.quarkus:quarkus-rest-client,io.quarkus:quarkus-rest-client-jackson,io.quarkus:quarkus-rest-client-jsonb

--- a/docs/src/main/asciidoc/rest.adoc
+++ b/docs/src/main/asciidoc/rest.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Writing REST Services with Quarkus REST (formerly RESTEasy Reactive)
 include::_attributes.adoc[]
-:categories: web
 :topics: rest,resteasy-reactive,virtual-threads
 :extensions: io.quarkus:quarkus-rest,io.quarkus:quarkus-rest-jackson,io.quarkus:quarkus-rest-jsonb,io.quarkus:quarkus-rest-client,io.quarkus:quarkus-rest-client-jackson,io.quarkus:quarkus-rest-client-jsonb
 :summary: Discover how to develop highly scalable reactive REST services with Jakarta REST and Quarkus REST.

--- a/docs/src/main/asciidoc/resteasy-client-multipart.adoc
+++ b/docs/src/main/asciidoc/resteasy-client-multipart.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using the legacy REST Client with Multipart
 include::_attributes.adoc[]
-:categories: web
 :summary: This guide explains how to use the RESTEasy Classic REST Client to send multipart REST requests, typically to upload documents.
 :topics: rest,rest-client,resteasy-client,multipart,resteasy-classic
 :extensions: io.quarkus:quarkus-resteasy-client,io.quarkus:quarkus-resteasy-multipart

--- a/docs/src/main/asciidoc/resteasy-client.adoc
+++ b/docs/src/main/asciidoc/resteasy-client.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using the legacy REST Client
 include::_attributes.adoc[]
-:categories: web
 :summary: This guide explains how to use the RESTEasy Classic REST Client in order to interact with REST APIs (JSON and other) with very little effort.
 :topics: rest,rest-client,resteasy-client,resteasy-classic
 :extensions: io.quarkus:quarkus-resteasy-client,io.quarkus:quarkus-resteasy-client-jackson,io.quarkus:quarkus-resteasy-client-jsonb,io.quarkus:quarkus-resteasy-client-jaxb

--- a/docs/src/main/asciidoc/resteasy.adoc
+++ b/docs/src/main/asciidoc/resteasy.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = RESTEasy Classic
 include::_attributes.adoc[]
-:categories: web
 :topics: rest,resteasy-classic
 :extensions: io.quarkus:quarkus-resteasy,io.quarkus:quarkus-resteasy-jackson,io.quarkus:quarkus-resteasy-jsonb
 

--- a/docs/src/main/asciidoc/scheduler-reference.adoc
+++ b/docs/src/main/asciidoc/scheduler-reference.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Scheduler Reference Guide
 include::_attributes.adoc[]
-:categories: miscellaneous
 :summary: Learn more about the Scheduler extension.
 :numbered:
 :sectnums:

--- a/docs/src/main/asciidoc/scheduler.adoc
+++ b/docs/src/main/asciidoc/scheduler.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Scheduling Periodic Tasks
 include::_attributes.adoc[]
-:categories: miscellaneous
 :summary: Modern applications often need to run specific tasks periodically. In this guide, you learn how to schedule periodic tasks.
 :topics: scheduling,cronjob
 :extensions: io.quarkus:quarkus-scheduler

--- a/docs/src/main/asciidoc/scripting.adoc
+++ b/docs/src/main/asciidoc/scripting.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Scripting with Quarkus
 include::_attributes.adoc[]
-:categories: command-line
 :summary: Easy Quarkus-based scripting with jbang.
 :extension-status: preview
 :topics: scripting,jbang

--- a/docs/src/main/asciidoc/security-architecture.adoc
+++ b/docs/src/main/asciidoc/security-architecture.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Quarkus Security architecture
 include::_attributes.adoc[]
 :diataxis-type: concept
-:categories: security
 :topics: security
 
 The Quarkus Security architecture provides several built-in authentication mechanisms and is highly customizable.

--- a/docs/src/main/asciidoc/security-authentication-mechanisms.adoc
+++ b/docs/src/main/asciidoc/security-authentication-mechanisms.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Authentication mechanisms in Quarkus
 include::_attributes.adoc[]
 :diataxis-type: concept
-:categories: security,web
 :topics: security,authentication
 
 The Quarkus Security framework supports multiple authentication mechanisms, which you can use to secure your applications.

--- a/docs/src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
+++ b/docs/src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Authorization of web endpoints
 include::_attributes.adoc[]
 :diataxis-type: reference
-:categories: security,web
 :topics: security,authorization,http,rest
 :extensions: io.quarkus:quarkus-vertx-http,io.quarkus:quarkus-rest,io.quarkus:quarkus-resteasy
 

--- a/docs/src/main/asciidoc/security-basic-authentication-howto.adoc
+++ b/docs/src/main/asciidoc/security-basic-authentication-howto.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Enable Basic authentication
 include::_attributes.adoc[]
 :diataxis-type: howto
-:categories: security
 :topics: security,authentication,basic-authentication,http
 :extensions: io.quarkus:quarkus-vertx-http,io.quarkus:quarkus-elytron-security-jdbc,io.quarkus:quarkus-elytron-security-ldap,io.quarkus:quarkus-security-jpa-reactive
 

--- a/docs/src/main/asciidoc/security-basic-authentication.adoc
+++ b/docs/src/main/asciidoc/security-basic-authentication.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Basic authentication
 include::_attributes.adoc[]
 :diataxis-type: concept
-:categories: security,web
 :topics: security,authentication,basic-authentication,http
 :extensions: io.quarkus:quarkus-vertx-http,io.quarkus:quarkus-elytron-security-jdbc,io.quarkus:quarkus-elytron-security-ldap,io.quarkus:quarkus-security-jpa-reactive
 

--- a/docs/src/main/asciidoc/security-cors.adoc
+++ b/docs/src/main/asciidoc/security-cors.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Cross-Origin Resource Sharing (CORS)
 include::_attributes.adoc[]
 :diataxis-type: reference
-:categories: security,web
 :summary: Enable and configure CORS in Quarkus to specify allowed origins, methods, and headers, guiding browsers in handling cross-origin requests safely.
 :keywords: cors,http,configuration, security, headers
 :extensions: io.quarkus:quarkus-vertx-http

--- a/docs/src/main/asciidoc/security-csrf-prevention.adoc
+++ b/docs/src/main/asciidoc/security-csrf-prevention.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Cross-Site Request Forgery Prevention
 include::_attributes.adoc[]
-:categories: security
 :topics: security,csrf,http
 :extensions: io.quarkus:quarkus-rest-csrf
 

--- a/docs/src/main/asciidoc/security-customization.adoc
+++ b/docs/src/main/asciidoc/security-customization.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Security Tips and Tricks
 include::_attributes.adoc[]
-:categories: security
 :topics: security
 :extensions: io.quarkus:quarkus-security
 

--- a/docs/src/main/asciidoc/security-getting-started-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-getting-started-tutorial.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Getting started with security by using Basic authentication and Jakarta Persistence
 include::_attributes.adoc[]
 :diataxis-type: tutorial
-:categories: security,getting-started
 :topics: security,authentication,basic-authentication,http
 :extensions: io.quarkus:quarkus-vertx-http,io.quarkus:quarkus-elytron-security-jdbc,io.quarkus:quarkus-elytron-security-ldap,io.quarkus:quarkus-security-jpa-reactive
 

--- a/docs/src/main/asciidoc/security-identity-providers.adoc
+++ b/docs/src/main/asciidoc/security-identity-providers.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Identity providers
 include::_attributes.adoc[]
 :diataxis-type: concept
-:categories: security
 :topics: security,identity-providers
 :extensions: io.quarkus:quarkus-elytron-security-jdbc,io.quarkus:quarkus-elytron-security-ldap,io.quarkus:quarkus-security-jpa-reactive
 

--- a/docs/src/main/asciidoc/security-jdbc.adoc
+++ b/docs/src/main/asciidoc/security-jdbc.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Security with JDBC
 include::_attributes.adoc[]
-:categories: security
 :summary: This guide demonstrates how your Quarkus application can use a database to store your user identities.
 :topics: security,identity-providers,jdbc,sql,database
 :extensions: io.quarkus:quarkus-elytron-security-jdbc

--- a/docs/src/main/asciidoc/security-jpa.adoc
+++ b/docs/src/main/asciidoc/security-jpa.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Quarkus Security with Jakarta Persistence
 include::_attributes.adoc[]
 :diataxis-type: howto
-:categories: security
 :topics: security,identity-providers,sql,database,jpa,jdbc
 :extensions: io.quarkus:quarkus-security-jpa-reactive
 

--- a/docs/src/main/asciidoc/security-jwt-build.adoc
+++ b/docs/src/main/asciidoc/security-jwt-build.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 [id="security-jwt-build"]
 = Build, sign, and encrypt JSON Web Tokens
 include::_attributes.adoc[]
-:categories: security
 :topics: security,jwt
 :extensions: io.quarkus:quarkus-smallrye-jwt-build
 

--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 [id="security-jwt"]
 = Using JWT RBAC
 include::_attributes.adoc[]
-:categories: security
 :summary: This guide explains how your application can use SmallRye JWT to provide secured access to the Jakarta REST endpoints.
 :extension-name: SmallRye JWT
 :mp-jwt: MicroProfile JWT RBAC

--- a/docs/src/main/asciidoc/security-keycloak-admin-client.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-admin-client.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Keycloak Admin Client
 include::_attributes.adoc[]
-:categories: security
 :keywords: sso oidc security keycloak
 :topics: security,authentication,authorization,keycloak,sso
 :extensions: io.quarkus:quarkus-keycloak-admin-rest-client,io.quarkus:quarkus-keycloak-admin-resteasy-client

--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Using OpenID Connect (OIDC) and Keycloak to centralize authorization
 include::_attributes.adoc[]
 :diataxis-type: howto
-:categories: security
 :keywords: sso, oidc, security, keycloak
 :topics: security, authentication, authorization, keycloak, sso, oidc
 :extensions: io.quarkus:quarkus-oidc, io.quarkus:quarkus-keycloak-authorization

--- a/docs/src/main/asciidoc/security-ldap.adoc
+++ b/docs/src/main/asciidoc/security-ldap.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Security with an LDAP Realm
 include::_attributes.adoc[]
-:categories: security
 :summary: This guide demonstrates how your Quarkus application can use a LDAP directory to store your user identities.
 :topics: security,identity-providers,ldap
 :extensions: io.quarkus:quarkus-elytron-security-ldap

--- a/docs/src/main/asciidoc/security-oauth2.adoc
+++ b/docs/src/main/asciidoc/security-oauth2.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using OAuth2 RBAC
 include::_attributes.adoc[]
-:categories: security
 :keywords: oauth
 :summary: This guide explains how your Quarkus application can utilize OAuth2 tokens to provide secured access to the Jakarta REST endpoints.
 :extension-name: Elytron Security OAuth2

--- a/docs/src/main/asciidoc/security-oidc-auth0-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-auth0-tutorial.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Protect a Quarkus web application by using an Auth0 OpenID Connect provider
 include::_attributes.adoc[]
 :diataxis-type: tutorial
-:categories: security,web
 :keywords: oidc,sso,auth0
 
 xref:security-architecture.adoc[Quarkus Security] provides comprehensive OpenId Connect (OIDC) and OAuth2 support with its `quarkus-oidc` extension, supporting both xref:security-oidc-code-flow-authentication.adoc[Authorization code flow] and xref:security-oidc-bearer-token-authentication.adoc[Bearer token] authentication mechanisms.

--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Protect a service application by using OpenID Connect (OIDC) Bearer token authentication
 include::_attributes.adoc[]
 :diataxis-type: tutorial
-:categories: security
 :topics: security,oidc,bearer-token,keycloak,authentication
 :extensions: io.quarkus:quarkus-oidc
 

--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = OpenID Connect (OIDC) Bearer token authentication
 include::_attributes.adoc[]
 :diataxis-type: concept
-:categories: security,web
 :topics: security,oidc,bearer-token,keycloak,authentication
 :extensions: io.quarkus:quarkus-oidc
 

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Protect a web application by using OpenID Connect (OIDC) authorization code flow
 include::_attributes.adoc[]
 :diataxis-type: tutorial
-:categories: security,web
 :topics: security,oidc,keycloak,authorization
 :extensions: io.quarkus:quarkus-oidc
 

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = OpenID Connect authorization code flow mechanism for protecting web applications
 include::_attributes.adoc[]
 :diataxis-type: concept
-:categories: security,web
 :toclevels: 4
 :topics: security,oidc,keycloak,authentication
 :extensions: io.quarkus:quarkus-oidc

--- a/docs/src/main/asciidoc/security-oidc-configuration-properties-reference.adoc
+++ b/docs/src/main/asciidoc/security-oidc-configuration-properties-reference.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = OpenID Connect (OIDC) configuration properties
 include::_attributes.adoc[]
 :diataxis-type: reference
-:categories: security
 :topics: security,oidc
 :extensions: io.quarkus:quarkus-oidc
 

--- a/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
+++ b/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Quarkus OpenId Connect (OIDC) Expanded Configuration Reference
 include::_attributes.adoc[]
 :diataxis-type: concept
-:categories: security
 :topics: security
 
 Quarkus OIDC `quarkus-oidc` extension provides a comprehensive, highly adaptable and configurable OIDC and OAuth2 adapter implementation.

--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = OpenID Connect (OIDC) and OAuth2 client and filters
 include::_attributes.adoc[]
 :diataxis-type: reference
-:categories: security
 :topics: security,oidc,client
 :extensions: io.quarkus:quarkus-oidc-client
 

--- a/docs/src/main/asciidoc/security-openid-connect-client-registration.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-registration.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = OpenID Connect (OIDC) and OAuth2 dynamic client registration
 include::_attributes.adoc[]
 :diataxis-type: reference
-:categories: security
 :topics: security,oidc,client
 :extensions: io.quarkus:quarkus-oidc-client-registration
 :extension-status: experimental

--- a/docs/src/main/asciidoc/security-openid-connect-client.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = OpenID Connect client and token propagation quickstart
 include::_attributes.adoc[]
 :diataxis-type: tutorial
-:categories: security
 :topics: security,oidc,client
 :extensions: io.quarkus:quarkus-oidc-client
 

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Dev Services and Dev UI for OpenID Connect (OIDC)
 include::_attributes.adoc[]
 :diataxis-type: howto
-:categories: security
 :keywords: sso oidc security keycloak
 :topics: security,oidc,keycloak,dev-services,testing,dev-mode
 :extensions: io.quarkus:quarkus-oidc

--- a/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Using OpenID Connect (OIDC) multitenancy
 include::_attributes.adoc[]
 :diataxis-type: howto
-:categories: security
 :keywords: sso oidc oauth2 security
 :topics: security,oidc,multitenancy
 :extensions: io.quarkus:quarkus-oidc

--- a/docs/src/main/asciidoc/security-openid-connect-providers.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-providers.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Configuring Well-Known OpenID Connect Providers
 include::_attributes.adoc[]
 :diataxis-type: concept
-:categories: security,web
 :keywords: oidc github twitter google facebook mastodon microsoft apple spotify twitch linkedin strava
 :toclevels: 3
 :topics: security,oidc,github,twitter,google,facebook,mastodon,microsoft,apple,spotify,twitch,linkedin,strava

--- a/docs/src/main/asciidoc/security-overview.adoc
+++ b/docs/src/main/asciidoc/security-overview.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Quarkus Security overview
 include::_attributes.adoc[]
 :diataxis-type: concept
-:categories: security
 :topics: security
 
 Quarkus Security is a framework that provides the architecture, multiple authentication and authorization mechanisms, and other tools to build secure and production-quality Java applications.

--- a/docs/src/main/asciidoc/security-proactive-authentication.adoc
+++ b/docs/src/main/asciidoc/security-proactive-authentication.adoc
@@ -8,7 +8,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Proactive authentication
 include::_attributes.adoc[]
 :diataxis-type: concept
-:categories: security,web
 :topics: security,authentication
 :extensions: io.quarkus:quarkus-vertx-http
 

--- a/docs/src/main/asciidoc/security-properties.adoc
+++ b/docs/src/main/asciidoc/security-properties.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Using Security with .properties File
 
 include::_attributes.adoc[]
-:categories: security
 :summary: This guide demonstrates how your Quarkus application can use a .properties file to store your user identities.
 :topics: security,identity-providers
 :extensions: io.quarkus:quarkus-elytron-security-properties-file

--- a/docs/src/main/asciidoc/security-testing.adoc
+++ b/docs/src/main/asciidoc/security-testing.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Security Testing
 include::_attributes.adoc[]
-:categories: security
 :topics: security,testing
 :extensions: io.quarkus:quarkus-test-security
 

--- a/docs/src/main/asciidoc/security-vertx-oidc-to-quarkus-oidc-migration.adoc
+++ b/docs/src/main/asciidoc/security-vertx-oidc-to-quarkus-oidc-migration.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Migrate from Vert.x OIDC to Quarkus OIDC
 include::_attributes.adoc[]
 :diataxis-type: tutorial
-:categories: security,web
 :topics: security,oidc,vertx
 :extensions: io.quarkus:quarkus-oidc
 

--- a/docs/src/main/asciidoc/security-vulnerability-detection.adoc
+++ b/docs/src/main/asciidoc/security-vulnerability-detection.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Security vulnerability detection and reporting in Quarkus
 include::_attributes.adoc[]
 :diataxis-type: concept
-:categories: security,contributing
 :topics: security,vulnerability
 
 Most of the Quarkus tags are registered in the US link:https://nvd.nist.gov[National Vulnerability Database (NVD)] in Common Platform Enumeration (CPE) name format.

--- a/docs/src/main/asciidoc/security-webauthn.adoc
+++ b/docs/src/main/asciidoc/security-webauthn.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Using Security with WebAuthn
 include::_attributes.adoc[]
 :extension-status: experimental
-:categories: security
 :topics: security,webauthn,authorization
 :extensions: io.quarkus:quarkus-security-webauthn
 :webauthn-api: https://javadoc.io/doc/io.quarkus/quarkus-security-webauthn/{quarkus-version}

--- a/docs/src/main/asciidoc/signals.adoc
+++ b/docs/src/main/asciidoc/signals.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus Signals
 include::_attributes.adoc[]
-:categories: miscellaneous
 :summary: Learn more about how application components can interact in a loosely coupled fashion
 :numbered:
 :sectnums:

--- a/docs/src/main/asciidoc/smallrye-fault-tolerance.adoc
+++ b/docs/src/main/asciidoc/smallrye-fault-tolerance.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = SmallRye Fault Tolerance
 include::_attributes.adoc[]
-:categories: web, observability
 :summary: This guide demonstrates how your Quarkus application can utilize the SmallRye Fault Tolerance specification through the SmallRye Fault Tolerance extension.
 :topics: fault-tolerance,resiliency
 :extensions: io.quarkus:quarkus-smallrye-fault-tolerance

--- a/docs/src/main/asciidoc/smallrye-graphql-client.adoc
+++ b/docs/src/main/asciidoc/smallrye-graphql-client.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = SmallRye GraphQL Client
 include::_attributes.adoc[]
-:categories: web
 :summary: This guide explains how to leverage SmallRye GraphQL Client to consume GraphQL services.
 :topics: graphql
 :extensions: io.quarkus:quarkus-smallrye-graphql-client

--- a/docs/src/main/asciidoc/smallrye-graphql.adoc
+++ b/docs/src/main/asciidoc/smallrye-graphql.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = SmallRye GraphQL
 include::_attributes.adoc[]
-:categories: web
 :summary: This guide explains how to leverage SmallRye GraphQL to implement GraphQL services.
 :topics: graphql
 :extensions: io.quarkus:quarkus-smallrye-graphql

--- a/docs/src/main/asciidoc/smallrye-health.adoc
+++ b/docs/src/main/asciidoc/smallrye-health.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = SmallRye Health
 include::_attributes.adoc[]
-:categories: observability
 :summary: This guide demonstrates how your Quarkus application can utilize the SmallRye Health extension.
 :topics: health,observability
 :extensions: io.quarkus:quarkus-smallrye-health

--- a/docs/src/main/asciidoc/software-transactional-memory.adoc
+++ b/docs/src/main/asciidoc/software-transactional-memory.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Software Transactional Memory in Quarkus
 include::_attributes.adoc[]
-:categories: data
 :summary: This guides covers the usage of Software Transactional Memory (STM).
 :extension-status: preview
 :topics: narayana,stm,transactions

--- a/docs/src/main/asciidoc/spring-boot-properties.adoc
+++ b/docs/src/main/asciidoc/spring-boot-properties.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Accessing application properties with Spring Boot properties API
 include::_attributes.adoc[]
-:categories: compatibility
 :summary: Use Spring Boot's @ConfigurationProperties in place of MicroProfile Config annotations
 :topics: spring,configuration,compatibility
 :extensions: io.quarkus:quarkus-spring-boot-properties

--- a/docs/src/main/asciidoc/spring-cache.adoc
+++ b/docs/src/main/asciidoc/spring-cache.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus Extension for Spring Cache API
 include::_attributes.adoc[]
-:categories: compatibility
 :summary: While you are encouraged to use the Cache extension for your application-level caching, Quarkus provides a compatibility layer for Spring Cache in the form of the spring-cache extension.
 :topics: spring,cache,compatibility
 :extensions: io.quarkus:quarkus-spring-cache

--- a/docs/src/main/asciidoc/spring-cloud-config-client.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config-client.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Reading properties from Spring Cloud Config Server
 include::_attributes.adoc[]
-:categories: compatibility
 :summary: Quarkus provides a compatibility layer for Spring Cloud Config in the form of the spring-cloud-config-client extension.
 :topics: spring,cloud,configuration,compatibility
 :extensions: io.quarkus:quarkus-spring-cloud-config-client

--- a/docs/src/main/asciidoc/spring-data-jpa.adoc
+++ b/docs/src/main/asciidoc/spring-data-jpa.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Extension for Spring Data API
 include::_attributes.adoc[]
-:categories: compatibility
 :summary: While you are encouraged to use Hibernate ORM with Panache for your data layer, Quarkus provides a compatibility layer for Spring Data JPA in the form of the spring-data-jpa extension.
 :topics: spring,data,hibernate-orm,jpa,compatibility
 :extensions: io.quarkus:quarkus-spring-data-jpa

--- a/docs/src/main/asciidoc/spring-data-rest.adoc
+++ b/docs/src/main/asciidoc/spring-data-rest.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Extension for Spring Data REST
 include::_attributes.adoc[]
-:categories: compatibility
 :summary: Spring Data REST simplifies the creation of CRUD applications based on our Spring Data compatibility layer.
 :topics: spring,data,hibernate-orm,jpa,rest,compatibility
 :extensions: io.quarkus:quarkus-spring-data-rest

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus Extension for Spring DI API
 include::_attributes.adoc[]
-:categories: compatibility
 :summary: While you are encouraged to use CDI annotations for injection, Quarkus provides a compatibility layer for Spring dependency injection in the form of the spring-di extension.
 :topics: spring,cdi,injection,compatibility
 :extensions: io.quarkus:quarkus-spring-di

--- a/docs/src/main/asciidoc/spring-scheduled.adoc
+++ b/docs/src/main/asciidoc/spring-scheduled.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus Extension for Spring Scheduling API
 include::_attributes.adoc[]
-:categories: compatibility
 :summary: While you are encouraged to use the Scheduler or Quartz extensions to schedule tasks, Quarkus provides a compatibility layer for Spring Scheduled in the form of the spring-scheduled extension.
 :topics: spring,scheduling,compatibility
 :extensions: io.quarkus:quarkus-spring-scheduled

--- a/docs/src/main/asciidoc/spring-security.adoc
+++ b/docs/src/main/asciidoc/spring-security.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus Extension for Spring Security API
 include::_attributes.adoc[]
-:categories: compatibility
 :summary: While you are encouraged to use the Quarkus Security layer to secure your applications, Quarkus provides a compatibility layer for Spring Security in the form of the spring-security extension.
 :topics: spring,security,compatibility
 :extensions: io.quarkus:quarkus-spring-security

--- a/docs/src/main/asciidoc/spring-tx.adoc
+++ b/docs/src/main/asciidoc/spring-tx.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus Extension for Spring Transaction API
 include::_attributes.adoc[]
-:categories: compatibility
 :summary: While you are encouraged to use Jakarta @Transactional directly, Quarkus provides a compatibility layer for Spring @Transactional in the form of the spring-tx extension.
 :topics: spring,transactions,compatibility
 :extensions: io.quarkus:quarkus-spring-tx

--- a/docs/src/main/asciidoc/spring-web.adoc
+++ b/docs/src/main/asciidoc/spring-web.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus Extension for Spring Web API
 include::_attributes.adoc[]
-:categories: compatibility
 :summary: While you are encouraged to use Jakarta REST annotations for defining REST endpoints, Quarkus provides a compatibility layer for Spring Web in the form of the spring-web extension.
 :topics: spring,rest,compatibility
 :extensions: io.quarkus:quarkus-spring-web

--- a/docs/src/main/asciidoc/stork-kubernetes.adoc
+++ b/docs/src/main/asciidoc/stork-kubernetes.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Using Stork with Kubernetes
 :extension-status: preview
 include::_attributes.adoc[]
-:categories: cloud
 :topics: service-discovery,load-balancing,stork,kubernetes
 :extensions: io.quarkus:quarkus-kubernetes,io.quarkus:quarkus-smallrye-stork
 

--- a/docs/src/main/asciidoc/stork-manual-service-registration.adoc
+++ b/docs/src/main/asciidoc/stork-manual-service-registration.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Implementing a Custom Stork Service Registrar
 :extension-status: preview
 include::_attributes.adoc[]
-:categories: cloud
 :topics: service-discovery,service-registration,stork
 :extensions: io.quarkus:quarkus-smallrye-stork
 

--- a/docs/src/main/asciidoc/stork-reference.adoc
+++ b/docs/src/main/asciidoc/stork-reference.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Stork Reference Guide
 :extension-status: preview
 include::_attributes.adoc[]
-:categories: cloud
 :topics: service-discovery,load-balancing,stork
 :extensions: io.quarkus:quarkus-smallrye-stork
 

--- a/docs/src/main/asciidoc/stork-registration.adoc
+++ b/docs/src/main/asciidoc/stork-registration.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Automatic service registration with SmallRye Stork for Quarkus
 :extension-status: preview
 include::_attributes.adoc[]
-:categories: cloud
 :topics: service-discovery, consul
 :extensions: io.quarkus:quarkus-smallrye-stork
 

--- a/docs/src/main/asciidoc/stork.adoc
+++ b/docs/src/main/asciidoc/stork.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Getting Started with SmallRye Stork
 :extension-status: preview
 include::_attributes.adoc[]
-:categories: cloud
 :topics: service-discovery,load-balancing,stork
 :extensions: io.quarkus:quarkus-smallrye-stork
 

--- a/docs/src/main/asciidoc/telemetry-micrometer-to-opentelemetry.adoc
+++ b/docs/src/main/asciidoc/telemetry-micrometer-to-opentelemetry.adoc
@@ -8,7 +8,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 include::_attributes.adoc[]
 :extension-status: preview
 :diataxis-type: reference
-:categories: observability
 :summary: Guide to send Micrometer data to OpenTelemetry.
 :topics: observability,opentelemetry,metrics,micrometer,tracing,logs
 :extensions: io.quarkus:quarkus-micrometer-opentelemetry

--- a/docs/src/main/asciidoc/telemetry-micrometer-tutorial.adoc
+++ b/docs/src/main/asciidoc/telemetry-micrometer-tutorial.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 [id="telemetry-micrometer-tutorial"]
 = Collect metrics using Micrometer
-:categories: observability
 :diataxis-type: tutorial
 include::_attributes.adoc[]
 :topics: observability,micrometer,prometheus

--- a/docs/src/main/asciidoc/telemetry-micrometer.adoc
+++ b/docs/src/main/asciidoc/telemetry-micrometer.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Micrometer Metrics
 include::_attributes.adoc[]
 :diataxis-type: reference
-:categories: observability
 :summary: Use Micrometer to collect metrics produced by Quarkus, its extensions, and your application.
 :base-units: https://github.com/micrometer-metrics/micrometer/blob/main/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/BaseUnits.java
 :concepts: https://docs.micrometer.io/micrometer/reference/concepts

--- a/docs/src/main/asciidoc/telemetry-opentracing-to-otel-tutorial.adoc
+++ b/docs/src/main/asciidoc/telemetry-opentracing-to-otel-tutorial.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 [id="telemetry-opentracing-to-otel-tutorial"]
 = Migrate from OpenTracing to OpenTelemetry tracing
-:categories: observability
 :diataxis-type: tutorial
 include::_attributes.adoc[]
 :topics: observability,opentracing,opentelemetry,tracing,migration

--- a/docs/src/main/asciidoc/testing-components.adoc
+++ b/docs/src/main/asciidoc/testing-components.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Testing components
 include::_attributes.adoc[]
-:categories: core,tooling
 :keywords: testing
 :summary:  This reference guide covers the `QuarkusComponentTestExtension`, a JUnit extension to ease the testing of components and mocking of their dependencies. 
 :numbered:

--- a/docs/src/main/asciidoc/tests-with-coverage.adoc
+++ b/docs/src/main/asciidoc/tests-with-coverage.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Measuring the coverage of your tests
 include::_attributes.adoc[]
-:categories: tooling
 :summary: This guide explains how to measure the test coverage of your Quarkus application.
 :numbered:
 :sectnums:

--- a/docs/src/main/asciidoc/tls-registry-reference.adoc
+++ b/docs/src/main/asciidoc/tls-registry-reference.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 [id="tls-registry-reference"]
 = {quarkus-tls-registry-reference-guide}
 include::_attributes.adoc[]
-:categories: web
 :summary: TLS registry configuration and usage
 :numbered:
 :sectnums:

--- a/docs/src/main/asciidoc/tooling.adoc
+++ b/docs/src/main/asciidoc/tooling.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using our Tooling
 include::_attributes.adoc[]
-:categories: getting-started
 :summary: Explore the Quarkus developer toolchain which makes Quarkus development so fast and enjoyable.
 :topics: tooling
 

--- a/docs/src/main/asciidoc/transaction.adoc
+++ b/docs/src/main/asciidoc/transaction.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Using transactions in Quarkus
 include::_attributes.adoc[]
 :diataxis-type: reference
-:categories: data,getting-started
 :topics: data,jpa,jta,transactions,narayana
 :extensions: io.quarkus:quarkus-narayana-jta
 

--- a/docs/src/main/asciidoc/update-quarkus.adoc
+++ b/docs/src/main/asciidoc/update-quarkus.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Update projects to the latest Quarkus version
 include::_attributes.adoc[]
 :diataxis-type: howto
-:categories: core
 :extension-status: "experimental"
 :summary: Learn how to upgrade your projects to the latest version of {project-name}
 :topics: tooling

--- a/docs/src/main/asciidoc/upx.adoc
+++ b/docs/src/main/asciidoc/upx.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Compressing native executables using UPX
 include::_attributes.adoc[]
-:categories: core
 :topics: tooling,native,compression,upx
 
 https://upx.github.io/[Ultimate Packer for eXecutables (UPX)] is a compression tool reducing the size of executables.

--- a/docs/src/main/asciidoc/validation.adoc
+++ b/docs/src/main/asciidoc/validation.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Validation with Hibernate Validator
 include::_attributes.adoc[]
-:categories: web, data
 :summary: This guide covers how to use Hibernate Validator/Bean Validation in your REST services.
 :topics: bean-validation,hibernate-validator,validation,validator,constraints
 :extensions: io.quarkus:quarkus-hibernate-validator

--- a/docs/src/main/asciidoc/vertx-reference.adoc
+++ b/docs/src/main/asciidoc/vertx-reference.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Vert.x Reference Guide
 include::_attributes.adoc[]
-:categories: miscellaneous
 :keywords: vertx event verticle
 :summary: This reference guide provides advanced details about the usage and the configuration of the Vert.x instance used by Quarkus.
 

--- a/docs/src/main/asciidoc/vertx.adoc
+++ b/docs/src/main/asciidoc/vertx.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Eclipse Vert.x API from a Quarkus Application
 include::_attributes.adoc[]
-:categories: miscellaneous
 :keywords: vertx event verticle
 :summary: This guide explains how to use Vert.x in Quarkus to build reactive applications.
 

--- a/docs/src/main/asciidoc/virtual-threads.adoc
+++ b/docs/src/main/asciidoc/virtual-threads.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Virtual Thread support reference
 include::_attributes.adoc[]
 :diataxis-type: reference
-:categories: core
 :resteasy-reactive-api: https://javadoc.io/doc/io.quarkus.resteasy.reactive/resteasy-reactive/{quarkus-version}
 :runonvthread: https://javadoc.io/doc/io.smallrye.common/smallrye-common-annotation/latest/io/smallrye/common/annotation/RunOnVirtualThread.html
 :blockingannotation: https://javadoc.io/doc/io.smallrye.common/smallrye-common-annotation/latest/io/smallrye/common/annotation/Blocking.html

--- a/docs/src/main/asciidoc/web-dependency-locator.adoc
+++ b/docs/src/main/asciidoc/web-dependency-locator.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Web dependency locator
 include::_attributes.adoc[]
-:categories: web
 :summary: Learn more about how to use the web dependency locator
 :numbered:
 :sectnums:

--- a/docs/src/main/asciidoc/web.adoc
+++ b/docs/src/main/asciidoc/web.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus for the Web
 include::_attributes.adoc[]
-:categories: web
 :summary: Learn more about creating all kinds of Web applications with Quarkus.
 :numbered:
 :sectnums:

--- a/docs/src/main/asciidoc/websockets-next-reference.adoc
+++ b/docs/src/main/asciidoc/websockets-next-reference.adoc
@@ -9,7 +9,6 @@ include::_attributes.adoc[]
 :numbered:
 :sectnums:
 :sectnumlevels: 4
-:categories: web
 :topics: web,websockets
 :extensions: io.quarkus:quarkus-websockets-next
 

--- a/docs/src/main/asciidoc/websockets-next-tutorial.adoc
+++ b/docs/src/main/asciidoc/websockets-next-tutorial.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Getting started with WebSockets Next
 include::_attributes.adoc[]
-:categories: web
 :diataxis-type: tutorial
 :summary: This guide explains how your Quarkus application can utilize web sockets to create interactive web applications. This guide uses the WebSockets Next extension
 :topics: web,websockets

--- a/docs/src/main/asciidoc/websockets.adoc
+++ b/docs/src/main/asciidoc/websockets.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using WebSockets with Undertow
 include::_attributes.adoc[]
-:categories: web
 :summary: This guide explains how your Quarkus application can utilize web sockets to create interactive web applications. Because it’s the canonical web socket application, we are going to create a simple chat application.
 :topics: web,websockets
 :extensions: io.quarkus:quarkus-websockets,io.quarkus:quarkus-websockets-client

--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Writing Your Own Extension
 include::_attributes.adoc[]
-:categories: writing-extensions
 :summary: Quarkus extensions optimize your applications by pushing as much work as possible to the build operation. This guide explains the rationale of Quarkus extensions and guides you through authoring your own extensions.
 :numbered:
 :sectnums:

--- a/docs/src/main/asciidoc/writing-native-applications-tips.adoc
+++ b/docs/src/main/asciidoc/writing-native-applications-tips.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Tips for writing native applications
 include::_attributes.adoc[]
-:categories: core, writing-extensions, native
 :summary: This guide is a collection of tips to help you solve the problems you encounter when compiling applications to native executable.
 :topics: native,extensions
 

--- a/docs/src/main/java/io/quarkus/docs/generation/CheckCategories.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/CheckCategories.java
@@ -41,17 +41,38 @@ public class CheckCategories {
         Set<String> missingGuides = new TreeSet<>(allGuides);
         missingGuides.removeAll(categorizedGuides);
 
+        Set<String> staleGuides = new TreeSet<>(categorizedGuides);
+        staleGuides.removeAll(allGuides);
+
+        StringBuilder errorLog = new StringBuilder();
         if (!missingGuides.isEmpty()) {
-            StringBuilder errorLog = new StringBuilder(
-                    "The following guides are not referenced in any category in categories.yaml:\n\n");
-            for (String guide : missingGuides) {
-                errorLog.append("- ").append(guide).append("\n");
-            }
-            errorLog.append("\nPlease add them to the appropriate category in src/main/resources/categories.yaml");
+            appendGuides(errorLog,
+                    "The following guides are not referenced in any category in categories.yaml:",
+                    missingGuides);
+            errorLog.append("\nPlease add them to the appropriate category in src/main/resources/categories.yaml\n");
+        }
+        if (!staleGuides.isEmpty()) {
+            appendGuides(errorLog,
+                    "The following guides are referenced in categories.yaml but do not exist:",
+                    staleGuides);
+            errorLog.append("\nPlease remove or update these entries in src/main/resources/categories.yaml\n");
+        }
+
+        if (errorLog.length() > 0) {
             throw new IllegalStateException(errorLog.toString());
         }
 
         System.out.println("[INFO] All guides are properly categorized");
+    }
+
+    private static void appendGuides(StringBuilder errorLog, String message, Set<String> guides) {
+        if (errorLog.length() > 0) {
+            errorLog.append("\n");
+        }
+        errorLog.append(message).append("\n\n");
+        for (String guide : guides) {
+            errorLog.append("- ").append(guide).append("\n");
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/docs/src/main/java/io/quarkus/docs/generation/CheckCategories.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/CheckCategories.java
@@ -5,18 +5,20 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 /**
- * Check that all guides are referenced in at least one category in categories.yaml.
+ * Check that categories.yaml references existing guides and uses category IDs known to the YAML metadata generator.
  */
 public class CheckCategories {
 
@@ -35,8 +37,12 @@ public class CheckCategories {
 
         System.out.println("[INFO] Checking categories using: " + categoriesFile);
 
+        Set<String> categoryIds = extractCategoryIdsFromCategories(categoriesFile);
         Set<String> categorizedGuides = extractGuidesFromCategories(categoriesFile);
         Set<String> allGuides = listGuides(srcDir);
+
+        Set<String> unknownCategoryIds = new TreeSet<>(categoryIds);
+        unknownCategoryIds.removeAll(knownYamlMetadataCategoryIds());
 
         Set<String> missingGuides = new TreeSet<>(allGuides);
         missingGuides.removeAll(categorizedGuides);
@@ -45,14 +51,21 @@ public class CheckCategories {
         staleGuides.removeAll(allGuides);
 
         StringBuilder errorLog = new StringBuilder();
+        if (!unknownCategoryIds.isEmpty()) {
+            appendEntries(errorLog,
+                    "The following top-level categories in categories.yaml are not recognized by YamlMetadataGenerator:",
+                    unknownCategoryIds);
+            errorLog.append(
+                    "\nPlease add them to YamlMetadataGenerator.Category or use an existing top-level category.\n");
+        }
         if (!missingGuides.isEmpty()) {
-            appendGuides(errorLog,
+            appendEntries(errorLog,
                     "The following guides are not referenced in any category in categories.yaml:",
                     missingGuides);
             errorLog.append("\nPlease add them to the appropriate category in src/main/resources/categories.yaml\n");
         }
         if (!staleGuides.isEmpty()) {
-            appendGuides(errorLog,
+            appendEntries(errorLog,
                     "The following guides are referenced in categories.yaml but do not exist:",
                     staleGuides);
             errorLog.append("\nPlease remove or update these entries in src/main/resources/categories.yaml\n");
@@ -65,14 +78,39 @@ public class CheckCategories {
         System.out.println("[INFO] All guides are properly categorized");
     }
 
-    private static void appendGuides(StringBuilder errorLog, String message, Set<String> guides) {
+    private static void appendEntries(StringBuilder errorLog, String message, Set<String> entries) {
         if (errorLog.length() > 0) {
             errorLog.append("\n");
         }
         errorLog.append(message).append("\n\n");
-        for (String guide : guides) {
-            errorLog.append("- ").append(guide).append("\n");
+        for (String entry : entries) {
+            errorLog.append("- ").append(entry).append("\n");
         }
+    }
+
+    static Set<String> knownYamlMetadataCategoryIds() {
+        return Arrays.stream(YamlMetadataGenerator.Category.values())
+                .map(category -> category.id)
+                .collect(Collectors.toSet());
+    }
+
+    @SuppressWarnings("unchecked")
+    static Set<String> extractCategoryIdsFromCategories(Path categoriesFile) throws IOException {
+        ObjectMapper om = new ObjectMapper(new YAMLFactory());
+
+        Map<String, Object> root;
+        try (InputStream is = Files.newInputStream(categoriesFile)) {
+            root = om.readValue(is, Map.class);
+        }
+
+        Set<String> categoryIds = new TreeSet<>();
+        List<Map<String, Object>> categories = (List<Map<String, Object>>) root.get("categories");
+        if (categories != null) {
+            for (Map<String, Object> category : categories) {
+                categoryIds.add((String) category.get("id"));
+            }
+        }
+        return categoryIds;
     }
 
     @SuppressWarnings("unchecked")

--- a/docs/src/main/java/io/quarkus/docs/generation/InjectCategories.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/InjectCategories.java
@@ -6,15 +6,17 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 /**
- * Inject the hierarchical category path from categories.yaml into each guide's :categories-path: attribute.
+ * Inject guide categories from categories.yaml into the copied AsciiDoc sources.
  * <p>
  * Runs on the copied .adoc files in target/asciidoc/sources/ so source files are not modified.
  */
@@ -26,27 +28,26 @@ public class InjectCategories {
 
         System.out.println("[INFO] Injecting categories from: " + categoriesFile);
 
-        Map<String, List<String>> guideToPaths = buildGuideToPaths(categoriesFile);
+        Map<String, GuideCategories> guideToCategories = buildGuideToCategories(categoriesFile);
 
         int count = 0;
         try (Stream<Path> files = Files.list(targetDir)) {
             for (Path file : (Iterable<Path>) files.filter(p -> p.toString().endsWith(".adoc"))::iterator) {
                 String filename = file.getFileName().toString();
-                List<String> paths = guideToPaths.get(filename);
-                if (paths == null || paths.isEmpty()) {
+                GuideCategories categories = guideToCategories.get(filename);
+                if (categories == null || categories.isEmpty()) {
                     continue;
                 }
-                String categoriesPathValue = String.join(",", paths);
-                injectAttribute(file, categoriesPathValue);
+                injectAttributes(file, categories.categoriesValue(), categories.pathsValue());
                 count++;
             }
         }
 
-        System.out.println("[INFO] Injected category paths into " + count + " guides");
+        System.out.println("[INFO] Injected categories into " + count + " guides");
     }
 
     @SuppressWarnings("unchecked")
-    static Map<String, List<String>> buildGuideToPaths(Path categoriesFile) throws IOException {
+    static Map<String, GuideCategories> buildGuideToCategories(Path categoriesFile) throws IOException {
         ObjectMapper om = new ObjectMapper(new YAMLFactory());
 
         Map<String, Object> root;
@@ -54,24 +55,24 @@ public class InjectCategories {
             root = om.readValue(is, Map.class);
         }
 
-        Map<String, List<String>> guideToPaths = new HashMap<>();
+        Map<String, GuideCategories> guideToCategories = new HashMap<>();
         List<Map<String, Object>> categories = (List<Map<String, Object>>) root.get("categories");
         if (categories != null) {
             for (Map<String, Object> category : categories) {
                 String id = (String) category.get("id");
-                collectPaths(category, id, guideToPaths);
+                collectCategories(category, id, id, guideToCategories);
             }
         }
-        return guideToPaths;
+        return guideToCategories;
     }
 
     @SuppressWarnings("unchecked")
-    private static void collectPaths(Map<String, Object> node, String currentPath,
-            Map<String, List<String>> guideToPaths) {
+    private static void collectCategories(Map<String, Object> node, String category, String currentPath,
+            Map<String, GuideCategories> guideToCategories) {
         List<String> guides = (List<String>) node.get("guides");
         if (guides != null) {
             for (String guide : guides) {
-                guideToPaths.computeIfAbsent(guide, k -> new ArrayList<>()).add(currentPath);
+                guideToCategories.computeIfAbsent(guide, k -> new GuideCategories()).add(category, currentPath);
             }
         }
 
@@ -79,12 +80,12 @@ public class InjectCategories {
         if (subcategories != null) {
             for (Map<String, Object> sub : subcategories) {
                 String subId = (String) sub.get("id");
-                collectPaths(sub, currentPath + "." + subId, guideToPaths);
+                collectCategories(sub, category, currentPath + "." + subId, guideToCategories);
             }
         }
     }
 
-    static void injectAttribute(Path file, String categoriesPathValue) throws IOException {
+    static void injectAttributes(Path file, String categoriesValue, String categoriesPathValue) throws IOException {
         List<String> lines = Files.readAllLines(file);
         List<String> result = new ArrayList<>(lines);
         int headerEnd = findHeaderEnd(result);
@@ -94,12 +95,11 @@ public class InjectCategories {
             return;
         }
 
+        int categoriesIndex = replaceOrInsertHeaderAttribute(result, headerEnd,
+                ":categories:", categoriesValue, findAttributeInsertionIndex(result, headerEnd));
+        headerEnd = findHeaderEnd(result);
         if (!replaceHeaderAttribute(result, headerEnd, ":categories-path:", categoriesPathValue)) {
-            int categoriesIndex = findHeaderAttribute(result, headerEnd, ":categories:");
-            int insertionIndex = categoriesIndex != -1
-                    ? categoriesIndex + 1
-                    : findAttributeInsertionIndex(result, headerEnd);
-            result.add(insertionIndex, ":categories-path: " + categoriesPathValue);
+            result.add(categoriesIndex + 1, ":categories-path: " + categoriesPathValue);
         }
         Files.write(file, result);
     }
@@ -134,6 +134,18 @@ public class InjectCategories {
         return true;
     }
 
+    private static int replaceOrInsertHeaderAttribute(List<String> lines, int headerEnd, String attribute, String value,
+            int insertionIndex) {
+        int attributeIndex = findHeaderAttribute(lines, headerEnd, attribute);
+        if (attributeIndex != -1) {
+            lines.set(attributeIndex, attribute + " " + value);
+            return attributeIndex;
+        }
+
+        lines.add(insertionIndex, attribute + " " + value);
+        return insertionIndex;
+    }
+
     private static int findHeaderAttribute(List<String> lines, int headerEnd, String attribute) {
         for (int i = 0; i < headerEnd; i++) {
             if (lines.get(i).startsWith(attribute)) {
@@ -155,5 +167,27 @@ public class InjectCategories {
             }
         }
         return headerEnd;
+    }
+
+    static final class GuideCategories {
+        private final Set<String> categories = new LinkedHashSet<>();
+        private final Set<String> paths = new LinkedHashSet<>();
+
+        private void add(String category, String path) {
+            categories.add(category);
+            paths.add(path);
+        }
+
+        boolean isEmpty() {
+            return categories.isEmpty() && paths.isEmpty();
+        }
+
+        String categoriesValue() {
+            return String.join(",", categories);
+        }
+
+        String pathsValue() {
+            return String.join(",", paths);
+        }
     }
 }

--- a/docs/src/main/java/io/quarkus/docs/generation/InjectCategories.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/InjectCategories.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 /**
- * Inject the hierarchical category path from categories.yaml into each guide's :categories: attribute.
+ * Inject the hierarchical category path from categories.yaml into each guide's :categories-path: attribute.
  * <p>
  * Runs on the copied .adoc files in target/asciidoc/sources/ so source files are not modified.
  */
@@ -36,13 +36,13 @@ public class InjectCategories {
                 if (paths == null || paths.isEmpty()) {
                     continue;
                 }
-                String categoriesValue = String.join(",", paths);
-                injectAttribute(file, categoriesValue);
+                String categoriesPathValue = String.join(",", paths);
+                injectAttribute(file, categoriesPathValue);
                 count++;
             }
         }
 
-        System.out.println("[INFO] Injected categories into " + count + " guides");
+        System.out.println("[INFO] Injected category paths into " + count + " guides");
     }
 
     @SuppressWarnings("unchecked")
@@ -84,45 +84,76 @@ public class InjectCategories {
         }
     }
 
-    static void injectAttribute(Path file, String categoriesValue) throws IOException {
+    static void injectAttribute(Path file, String categoriesPathValue) throws IOException {
         List<String> lines = Files.readAllLines(file);
-        List<String> result = new ArrayList<>(lines.size());
-        boolean replaced = false;
+        List<String> result = new ArrayList<>(lines);
+        int headerEnd = findHeaderEnd(result);
 
-        for (String line : lines) {
-            if (line.startsWith(":categories:")) {
-                result.add(":categories: " + categoriesValue);
-                replaced = true;
-            } else {
-                result.add(line);
-            }
+        if (headerEnd == -1) {
+            System.out.println("[WARN] Unable to find document header in: " + file);
+            return;
         }
 
-        if (!replaced) {
-            // Insert after the include::_attributes.adoc[] line if present, otherwise after the title
-            List<String> output = new ArrayList<>(lines.size() + 1);
-            boolean inserted = false;
-            for (String line : lines) {
-                output.add(line);
-                if (!inserted && line.startsWith("include::_attributes.adoc[]")) {
-                    output.add(":categories: " + categoriesValue);
-                    inserted = true;
-                }
-            }
-            if (!inserted) {
-                for (int i = 0; i < lines.size(); i++) {
-                    if (lines.get(i).startsWith("= ")) {
-                        output = new ArrayList<>(lines.size() + 1);
-                        output.addAll(lines.subList(0, i + 1));
-                        output.add(":categories: " + categoriesValue);
-                        output.addAll(lines.subList(i + 1, lines.size()));
-                        break;
-                    }
-                }
-            }
-            result = output;
+        if (!replaceHeaderAttribute(result, headerEnd, ":categories-path:", categoriesPathValue)) {
+            int categoriesIndex = findHeaderAttribute(result, headerEnd, ":categories:");
+            int insertionIndex = categoriesIndex != -1
+                    ? categoriesIndex + 1
+                    : findAttributeInsertionIndex(result, headerEnd);
+            result.add(insertionIndex, ":categories-path: " + categoriesPathValue);
         }
-
         Files.write(file, result);
+    }
+
+    private static int findHeaderEnd(List<String> lines) {
+        int titleIndex = -1;
+        for (int i = 0; i < lines.size(); i++) {
+            if (lines.get(i).startsWith("= ")) {
+                titleIndex = i;
+                break;
+            }
+        }
+        if (titleIndex == -1) {
+            return -1;
+        }
+
+        for (int i = titleIndex + 1; i < lines.size(); i++) {
+            if (lines.get(i).isBlank()) {
+                return i;
+            }
+        }
+        return lines.size();
+    }
+
+    private static boolean replaceHeaderAttribute(List<String> lines, int headerEnd, String attribute, String value) {
+        int attributeIndex = findHeaderAttribute(lines, headerEnd, attribute);
+        if (attributeIndex == -1) {
+            return false;
+        }
+
+        lines.set(attributeIndex, attribute + " " + value);
+        return true;
+    }
+
+    private static int findHeaderAttribute(List<String> lines, int headerEnd, String attribute) {
+        for (int i = 0; i < headerEnd; i++) {
+            if (lines.get(i).startsWith(attribute)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static int findAttributeInsertionIndex(List<String> lines, int headerEnd) {
+        for (int i = 0; i < headerEnd; i++) {
+            if (lines.get(i).startsWith("include::_attributes.adoc[]")) {
+                return i + 1;
+            }
+        }
+        for (int i = 0; i < headerEnd; i++) {
+            if (lines.get(i).startsWith("= ")) {
+                return i + 1;
+            }
+        }
+        return headerEnd;
     }
 }

--- a/docs/src/main/java/io/quarkus/docs/generation/YamlMetadataGenerator.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/YamlMetadataGenerator.java
@@ -281,12 +281,16 @@ public class YamlMetadataGenerator {
         contributing("contributing", "Contributing"),
         core("core", "Core"),
         data("data", "Data"),
+        execution_model("execution-model", "Execution Model"),
         getting_started("getting-started", "Getting Started"),
         integration("integration", "Integration"),
         messaging("messaging", "Messaging"),
         miscellaneous("miscellaneous", "Miscellaneous"),
         native_docs("native", "Native"),
         observability("observability", "Observability"),
+        operations("operations", "Operations"),
+        packaging("packaging", "Packaging"),
+        rule_engine("rule-engine", "Rule Engine"),
         security("security", "Security"),
         serialization("serialization", "Serialization"),
         tooling("tooling", "Tooling"),
@@ -444,7 +448,7 @@ public class YamlMetadataGenerator {
                 case "missing-id":
                     return "Document does not define an id. See https://quarkus.io/guides/doc-reference#document-header";
                 case "missing-categories":
-                    return "Document does not specify associated categories. See https://quarkus.io/guides/doc-reference#categories";
+                    return "Document is not listed in categories.yaml. See https://quarkus.io/guides/doc-reference#categories";
                 case "not-diataxis-type":
                     return "Document type not recognized. It either does not have a diataxis-type attribute or does not follow naming conventions. See https://quarkus.io/guides/doc-reference#document-header";
                 case "toc":

--- a/docs/src/main/resources/categories.yaml
+++ b/docs/src/main/resources/categories.yaml
@@ -1,5 +1,9 @@
 # Quarkus Guides - Category Structure with Guides
 # Hierarchical organization of all guide categories and their guides
+#
+# This file is the source of truth for guide categories.
+# Do not maintain :categories: attributes in guide headers.
+# The docs build injects generated category metadata into copied target sources.
 
 categories:
   - id: getting-started

--- a/docs/src/main/resources/categories.yaml
+++ b/docs/src/main/resources/categories.yaml
@@ -139,7 +139,6 @@ categories:
           - hibernate-orm-panache-kotlin.adoc
           - hibernate-reactive.adoc
           - hibernate-reactive-panache.adoc
-          - hibernate-panache-next.adoc
           - hibernate-search-orm-elasticsearch.adoc
           - hibernate-search-standalone-elasticsearch.adoc
           - blaze-persistence.adoc
@@ -547,4 +546,3 @@ categories:
     description: Business rules with Drools
     guides:
       - drools.adoc
-

--- a/docs/src/test/java/io/quarkus/docs/generation/CheckCategoriesTest.java
+++ b/docs/src/test/java/io/quarkus/docs/generation/CheckCategoriesTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.docs.generation;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class CheckCategoriesTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void shouldReportGuidesReferencedInCategoriesButMissingFromSourceTree() throws Exception {
+        Path srcDir = tempDir.resolve("src");
+        Files.createDirectories(srcDir);
+        Files.writeString(srcDir.resolve("existing.adoc"), "= Existing\n");
+
+        Path categoriesFile = tempDir.resolve("categories.yaml");
+        Files.writeString(categoriesFile, String.join("\n",
+                "categories:",
+                "  - id: web",
+                "    title: Web",
+                "    guides:",
+                "      - existing.adoc",
+                "      - missing.adoc",
+                ""));
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> CheckCategories.main(new String[] { srcDir.toString(), categoriesFile.toString() }));
+
+        assertTrue(exception.getMessage().contains("missing.adoc"));
+        assertTrue(exception.getMessage().contains("referenced in categories.yaml but do not exist"));
+    }
+}

--- a/docs/src/test/java/io/quarkus/docs/generation/CheckCategoriesTest.java
+++ b/docs/src/test/java/io/quarkus/docs/generation/CheckCategoriesTest.java
@@ -36,4 +36,26 @@ public class CheckCategoriesTest {
         assertTrue(exception.getMessage().contains("missing.adoc"));
         assertTrue(exception.getMessage().contains("referenced in categories.yaml but do not exist"));
     }
+
+    @Test
+    public void shouldReportTopLevelCategoriesUnknownToMetadataGenerator() throws Exception {
+        Path srcDir = tempDir.resolve("src");
+        Files.createDirectories(srcDir);
+        Files.writeString(srcDir.resolve("existing.adoc"), "= Existing\n");
+
+        Path categoriesFile = tempDir.resolve("categories.yaml");
+        Files.writeString(categoriesFile, String.join("\n",
+                "categories:",
+                "  - id: not-a-known-category",
+                "    title: Unknown",
+                "    guides:",
+                "      - existing.adoc",
+                ""));
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> CheckCategories.main(new String[] { srcDir.toString(), categoriesFile.toString() }));
+
+        assertTrue(exception.getMessage().contains("not-a-known-category"));
+        assertTrue(exception.getMessage().contains("not recognized by YamlMetadataGenerator"));
+    }
 }

--- a/docs/src/test/java/io/quarkus/docs/generation/InjectCategoriesTest.java
+++ b/docs/src/test/java/io/quarkus/docs/generation/InjectCategoriesTest.java
@@ -1,10 +1,15 @@
 package io.quarkus.docs.generation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -15,7 +20,7 @@ public class InjectCategoriesTest {
     Path tempDir;
 
     @Test
-    public void shouldOnlyInjectCategoryPathInDocumentHeader() throws Exception {
+    public void shouldOnlyInjectCategoriesInDocumentHeader() throws Exception {
         Path guide = tempDir.resolve("guide.adoc");
         Files.writeString(guide, String.join("\n",
                 "[id=\"guide\"]",
@@ -29,16 +34,16 @@ public class InjectCategoriesTest {
                 "----",
                 ""));
 
-        InjectCategories.injectAttribute(guide, "contributing.docs");
+        InjectCategories.injectAttributes(guide, "contributing", "contributing.docs");
 
         List<String> lines = Files.readAllLines(guide);
-        assertEquals(":categories: data", lines.get(3));
+        assertEquals(":categories: contributing", lines.get(3));
         assertEquals(":categories-path: contributing.docs", lines.get(4));
         assertEquals(":categories: web // <4>", lines.get(8));
     }
 
     @Test
-    public void shouldInsertCategoryPathAfterAttributesInclude() throws Exception {
+    public void shouldInsertCategoriesAfterAttributesInclude() throws Exception {
         Path guide = tempDir.resolve("guide.adoc");
         Files.writeString(guide, String.join("\n",
                 "[id=\"guide\"]",
@@ -48,9 +53,58 @@ public class InjectCategoriesTest {
                 "Content",
                 ""));
 
-        InjectCategories.injectAttribute(guide, "web.web-rest");
+        InjectCategories.injectAttributes(guide, "web", "web.web-rest");
 
         List<String> lines = Files.readAllLines(guide);
-        assertEquals(":categories-path: web.web-rest", lines.get(3));
+        assertEquals(":categories: web", lines.get(3));
+        assertEquals(":categories-path: web.web-rest", lines.get(4));
+    }
+
+    @Test
+    public void shouldBuildFlatCategoriesAndCategoryPathsFromHierarchy() throws Exception {
+        Path categoriesFile = tempDir.resolve("categories.yaml");
+        Files.writeString(categoriesFile, String.join("\n",
+                "categories:",
+                "  - id: web",
+                "    title: Web",
+                "    subcategories:",
+                "      - id: web-rest",
+                "        title: REST",
+                "        guides:",
+                "          - rest-json.adoc",
+                "  - id: serialization",
+                "    title: Serialization",
+                "    subcategories:",
+                "      - id: serialization-json",
+                "        title: JSON",
+                "        guides:",
+                "          - rest-json.adoc",
+                ""));
+
+        Map<String, InjectCategories.GuideCategories> categories = InjectCategories.buildGuideToCategories(categoriesFile);
+
+        InjectCategories.GuideCategories guideCategories = categories.get("rest-json.adoc");
+        assertEquals("web,serialization", guideCategories.categoriesValue());
+        assertEquals("web.web-rest,serialization.serialization-json", guideCategories.pathsValue());
+    }
+
+    @Test
+    public void generatedCategoriesShouldBeKnownToYamlMetadataGenerator() throws Exception {
+        Path categoriesFile = Path.of("src/main/resources/categories.yaml");
+        if (!Files.exists(categoriesFile)) {
+            categoriesFile = Path.of("docs/src/main/resources/categories.yaml");
+        }
+
+        Set<String> metadataCategories = Arrays.stream(YamlMetadataGenerator.Category.values())
+                .map(category -> category.id)
+                .collect(Collectors.toSet());
+
+        Set<String> generatedCategories = InjectCategories.buildGuideToCategories(categoriesFile).values().stream()
+                .flatMap(categories -> Arrays.stream(categories.categoriesValue().split(",")))
+                .collect(Collectors.toSet());
+
+        generatedCategories.removeAll(metadataCategories);
+        assertTrue(generatedCategories.isEmpty(),
+                "categories.yaml contains categories that YamlMetadataGenerator does not accept: " + generatedCategories);
     }
 }

--- a/docs/src/test/java/io/quarkus/docs/generation/InjectCategoriesTest.java
+++ b/docs/src/test/java/io/quarkus/docs/generation/InjectCategoriesTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.docs.generation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class InjectCategoriesTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void shouldOnlyInjectCategoryPathInDocumentHeader() throws Exception {
+        Path guide = tempDir.resolve("guide.adoc");
+        Files.writeString(guide, String.join("\n",
+                "[id=\"guide\"]",
+                "= Guide",
+                "include::_attributes.adoc[]",
+                ":categories: data",
+                "",
+                "[source,asciidoc]",
+                "----",
+                ":categories: web // <4>",
+                "----",
+                ""));
+
+        InjectCategories.injectAttribute(guide, "contributing.docs");
+
+        List<String> lines = Files.readAllLines(guide);
+        assertEquals(":categories: data", lines.get(3));
+        assertEquals(":categories-path: contributing.docs", lines.get(4));
+        assertEquals(":categories: web // <4>", lines.get(8));
+    }
+
+    @Test
+    public void shouldInsertCategoryPathAfterAttributesInclude() throws Exception {
+        Path guide = tempDir.resolve("guide.adoc");
+        Files.writeString(guide, String.join("\n",
+                "[id=\"guide\"]",
+                "= Guide",
+                "include::_attributes.adoc[]",
+                "",
+                "Content",
+                ""));
+
+        InjectCategories.injectAttribute(guide, "web.web-rest");
+
+        List<String> lines = Files.readAllLines(guide);
+        assertEquals(":categories-path: web.web-rest", lines.get(3));
+    }
+}


### PR DESCRIPTION
Hello G, @gsmet 
I prepared an optional helper PR against your `doc-categories` branch: 
https://github.com/quarkusio/quarkus/pull/54877

It is not a direct push to your branch.
It is just a small patch that you can cherry-pick, rework, or ignore.

I kept it limited to the mechanical pieces:

- keep the existing flat `:categories:` values untouched
- inject the hierarchy into `:categories-path:` instead
- scope the injection to the document header so `[source,asciidoc]` examples are not rewritten
- add reverse validation for stale entries in `categories.yaml`
- remove `hibernate-panache-next.adoc`, which is stale on the PR branch

The helper PR intentionally does not try to solve `target/categories.yaml`.

The current sync hook copies that file if it is present, but this PR does not produce it yet.
Also, the companion website experiment appears to consume enriched guide objects rather than the raw `src/main/resources/categories.yaml` shape, so I think that part needs your intended design before implementing anything.

One merge-ref note: on the current `main` merge ref, `grpc-xds.adoc` is also stale, and the newer guides `http3-reference.adoc`, `native-transport-reference.adoc`, `security-spiffe-client.adoc`, and `spring-test.adoc` need categorization.

I did not include those in the helper branch because they are not present in `doc-categories` itself.

One remaining design question I did not try to solve in the helper PR:

`sync-web-site.sh` now looks for `target/categories.yaml`, but this PR does not currently generate that file.

Should this PR generate a website-ready `target/categories.yaml` as part of the docs metadata generation, or is the sync hook intentionally a placeholder for the companion website PR?

I also noticed that the website experiment seems to consume an enriched category structure with guide metadata, including `filename`, `title`, `summary`, `url`, `type`, topics, and extensions, rather than only the raw filename lists from `src/main/resources/categories.yaml`.

Because of that, I did not add a simple copy step.
I was not sure which output shape you want to use as the source of truth.