### PR TITLE
Make category consistency test independent of working directory

### DIFF
--- a/docs/src/test/java/io/quarkus/docs/generation/InjectCategoriesTest.java
+++ b/docs/src/test/java/io/quarkus/docs/generation/InjectCategoriesTest.java
@@ -1,8 +1,10 @@
 package io.quarkus.docs.generation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -90,10 +92,9 @@ public class InjectCategoriesTest {
 
     @Test
     public void generatedCategoriesShouldBeKnownToYamlMetadataGenerator() throws Exception {
-        Path categoriesFile = Path.of("src/main/resources/categories.yaml");
-        if (!Files.exists(categoriesFile)) {
-            categoriesFile = Path.of("docs/src/main/resources/categories.yaml");
-        }
+        URL categoriesResource = InjectCategoriesTest.class.getClassLoader().getResource("categories.yaml");
+        assertNotNull(categoriesResource, "categories.yaml must be available on the test classpath");
+        Path categoriesFile = Path.of(categoriesResource.toURI());
 
         Set<String> metadataCategories = Arrays.stream(YamlMetadataGenerator.Category.values())
                 .map(category -> category.id)


### PR DESCRIPTION
Hi Guillaume, the full PR, https://github.com/quarkusio/quarkus/pull/54877 , looks good now!

There is only one small follow-up remaining: `InjectCategoriesTest` previously resolved `categories.yaml` relative to the process working directory, which could fail when the test was launched from an IDE or another Maven context. Commit `9d16c78fe0e` resolves the file from the test classpath instead. This does not change production behavior.

Feel free to cherry-pick it into `doc-categories` if useful.
Otherwise, great contribution and a leap forward, @gsmet. GJ